### PR TITLE
Add optional ssl_ca_cert/private_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ EOF
 - region: **(required)** Region you want to deploy your resources to
 - availability_zones: **(required)** List of AZs you want to deploy to
 - dns_suffix: **(required)** Domain to add environment subdomain to
-- ssl_cert: **(required)** SSL certificate for HTTP load balancer configuration. Can be either trusted or self-signed.
-- ssl_private_key: **(required)** Private key for above SSL certificate.
+- ssl_cert: **(optional)** SSL certificate for HTTP load balancer configuration. Required unless `ssl_ca_cert` is specified.
+- ssl_private_key: **(optional)** Private key for above SSL certificate. Required unless `ssl_ca_cert` is specified.
+- ssl_ca_cert: **(optional)** SSL CA certificate used to generate self-signed HTTP load balancer certificate. Required unless `ssl_cert` is specified.
+- ssl_ca_private_key: **(optional)** Private key for above SSL CA certificate. Required unless `ssl_cert` is specified.
 
 ## Ops Manager (optional)
 - ops_manager: **(default: true)** Set to false if you don't want an Ops Manager
@@ -96,9 +98,11 @@ EOF
 - rds_db_username: **(default: admin)** Username for RDS authentication
 
 ## Isolation Segments (optional)
-- create_isoseg_resources *(optional)* Set to 1 to create HTTP load-balancer across 3 zones for isolation segments. If set, the following 2 isoseg variables are also required.
-- isoseg_ssl_cert: *(optional)* SSL certificate for HTTP load balancer configuration. Can be either trusted or self-signed.
-- isoseg_ssl_private_key:  *(optional)* Private key for above SSL certificate.
+- create_isoseg_resources **(optional)** Set to 1 to create HTTP load-balancer across 3 zones for isolation segments.
+- isoseg_ssl_cert: **(optional)** SSL certificate for Iso Seg HTTP load balancer configuration. Required unless `isoseg_ssl_ca_cert` is specified.
+- isoseg_ssl_private_key: **(optional)** Private key for above SSL certificate. Required unless `isoseg_ssl_ca_cert` is specified.
+- isoseg_ssl_ca_cert: **(optional)** SSL CA certificate used to generate self-signed Iso Seg HTTP load balancer certificate. Required unless `isoseg_ssl_cert` is specified.
+- isoseg_ssl_ca_private_key: **(optional)** Private key for above SSL CA certificate. Required unless `isoseg_ssl_cert` is specified.
 
 ## Running
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -154,6 +154,16 @@ output "web_elb_name" {
   value = "${aws_elb.web_elb.name}"
 }
 
+output "ssl_cert" {
+  sensitive = true
+  value     = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_locally_signed_cert.ssl_cert.*.cert_pem, list("")), 0) : var.ssl_cert}"
+}
+
+output "ssl_private_key" {
+  sensitive = true
+  value     = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_private_key.ssl_private_key.*.private_key_pem, list("")), 0) : var.ssl_private_key}"
+}
+
 output "ssh_elb_name" {
   value = "${aws_elb.ssh_elb.name}"
 }
@@ -164,6 +174,16 @@ output "tcp_elb_name" {
 
 output "isoseg_elb_name" {
   value = "${element(concat(aws_elb.isoseg.*.name, list("")), 0)}"
+}
+
+output "isoseg_ssl_cert" {
+  sensitive = true
+  value     = "${length(var.isoseg_ssl_ca_cert) > 0 ? element(concat(tls_locally_signed_cert.isoseg_ssl_cert.*.cert_pem, list("")), 0) : var.isoseg_ssl_cert}"
+}
+
+output "isoseg_ssl_private_key" {
+  sensitive = true
+  value     = "${length(var.isoseg_ssl_ca_cert) > 0 ? element(concat(tls_private_key.isoseg_ssl_private_key.*.private_key_pem, list("")), 0) : var.isoseg_ssl_private_key}"
 }
 
 output "dns_zone_id" {

--- a/self_signed_certs.tf
+++ b/self_signed_certs.tf
@@ -1,0 +1,88 @@
+resource "tls_cert_request" "ssl_csr" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.ssl_private_key.private_key_pem}"
+
+  dns_names = [
+    "*.apps.${var.env_name}.${var.dns_suffix}",
+    "*.sys.${var.env_name}.${var.dns_suffix}",
+  ]
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+
+  subject {
+    common_name         = "${var.env_name}.${var.dns_suffix}"
+    organization        = "Pivotal"
+    organizational_unit = "Cloudfoundry"
+    country             = "US"
+    province            = "CA"
+    locality            = "San Francisco"
+  }
+}
+
+resource "tls_locally_signed_cert" "ssl_cert" {
+  cert_request_pem   = "${tls_cert_request.ssl_csr.cert_request_pem}"
+  ca_key_algorithm   = "RSA"
+  ca_private_key_pem = "${var.ssl_ca_private_key}"
+  ca_cert_pem        = "${var.ssl_ca_cert}"
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+
+  validity_period_hours = 8760 # 1year
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "tls_private_key" "ssl_private_key" {
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+
+  count = "${length(var.ssl_ca_cert) > 0 ? 1 : 0}"
+}
+
+resource "tls_cert_request" "isoseg_ssl_csr" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.isoseg_ssl_private_key.private_key_pem}"
+
+  dns_names = [
+    "*.iso.${var.env_name}.${var.dns_suffix}",
+  ]
+
+  count = "${length(var.isoseg_ssl_ca_cert) > 0 ? 1 : 0}"
+
+  subject {
+    common_name         = "${var.env_name}.${var.dns_suffix}"
+    organization        = "Pivotal"
+    organizational_unit = "Cloudfoundry"
+    country             = "US"
+    province            = "CA"
+    locality            = "San Francisco"
+  }
+}
+
+resource "tls_locally_signed_cert" "isoseg_ssl_cert" {
+  cert_request_pem   = "${tls_cert_request.isoseg_ssl_csr.cert_request_pem}"
+  ca_key_algorithm   = "RSA"
+  ca_private_key_pem = "${var.isoseg_ssl_ca_private_key}"
+  ca_cert_pem        = "${var.isoseg_ssl_ca_cert}"
+
+  count = "${length(var.isoseg_ssl_ca_cert) > 0 ? 1 : 0}"
+
+  validity_period_hours = 8760 # 1year
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "tls_private_key" "isoseg_ssl_private_key" {
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+
+  count = "${length(var.isoseg_ssl_ca_cert) > 0 ? 1 : 0}"
+}

--- a/ssl_cert.tf
+++ b/ssl_cert.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_server_certificate" "cert" {
   name_prefix      = "${var.env_name}-"
-  certificate_body = "${var.ssl_cert}"
-  private_key      = "${var.ssl_private_key}"
+  certificate_body = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_locally_signed_cert.ssl_cert.*.cert_pem, list("")), 0) : var.ssl_cert}"
+  private_key      = "${length(var.ssl_ca_cert) > 0 ? element(concat(tls_private_key.ssl_private_key.*.private_key_pem, list("")), 0) : var.ssl_private_key}"
 
   lifecycle {
     create_before_destroy = true
@@ -12,8 +12,8 @@ resource "aws_iam_server_certificate" "isoseg_cert" {
   count = "${var.create_isoseg_resources}"
 
   name_prefix      = "${var.env_name}-isoseg"
-  certificate_body = "${var.isoseg_ssl_cert}"
-  private_key      = "${var.isoseg_ssl_private_key}"
+  certificate_body = "${length(var.isoseg_ssl_ca_cert) > 0 ? element(concat(tls_locally_signed_cert.isoseg_ssl_cert.*.cert_pem, list("")), 0) : var.isoseg_ssl_cert}"
+  private_key      = "${length(var.isoseg_ssl_ca_cert) > 0 ? element(concat(tls_private_key.isoseg_ssl_private_key.*.private_key_pem, list("")), 0) : var.isoseg_ssl_private_key}"
 
   lifecycle {
     create_before_destroy = true

--- a/variables.tf
+++ b/variables.tf
@@ -47,13 +47,25 @@ variable "optional_ops_manager" {
 
 variable "ssl_cert" {
   type        = "string"
-  description = "ssl certificate content"
+  description = "the contents of an SSL certificate to be used by the LB, optional if `ssl_ca_cert` is provided"
   default     = ""
 }
 
 variable "ssl_private_key" {
   type        = "string"
-  description = "ssl certificate private key content"
+  description = "the contents of an SSL private key to be used by the LB, optional if `ssl_ca_cert` is provided"
+  default     = ""
+}
+
+variable "ssl_ca_cert" {
+  type        = "string"
+  description = "the contents of a CA public key to be used to sign the generated LB certificate, optional if `ssl_cert` is provided"
+  default     = ""
+}
+
+variable "ssl_ca_private_key" {
+  type        = "string"
+  description = "the contents of a CA private key to be used to sign the generated LB certificate, optional if `ssl_cert` is provided"
   default     = ""
 }
 
@@ -63,13 +75,25 @@ variable "ssl_private_key" {
 
 variable "isoseg_ssl_cert" {
   type        = "string"
-  description = "ssl certificate content"
+  description = "the contents of an SSL certificate to be used by the LB, optional if `isoseg_ssl_ca_cert` is provided"
   default     = ""
 }
 
 variable "isoseg_ssl_private_key" {
   type        = "string"
-  description = "ssl certificate private key content"
+  description = "the contents of an SSL private key to be used by the LB, optional if `isoseg_ssl_ca_cert` is provided"
+  default     = ""
+}
+
+variable "isoseg_ssl_ca_cert" {
+  type        = "string"
+  description = "the contents of a CA public key to be used to sign the generated iso seg LB certificate, optional if `isoseg_ssl_cert` is provided"
+  default     = ""
+}
+
+variable "isoseg_ssl_ca_private_key" {
+  type        = "string"
+  description = "the contents of a CA private key to be used to sign the generated iso seg LB certificate, optional if `isoseg_ssl_cert` is provided"
   default     = ""
 }
 


### PR DESCRIPTION
Hi Infrastructure team!

This PR adds support for an optional CA cert and key to allow the templates to generate a verifiable certificate for the PAS load balancers. If the CA is not provided, the user must continue to provide the cert/key to use.

Let us know if you have any questions.

@acrmp and @davewalter