### PR TITLE
adds us-east-2 region to map

### DIFF
--- a/nat.tf
+++ b/nat.tf
@@ -3,6 +3,7 @@ variable "nat_ami_map" {
 
   default = {
     us-east-1      = "ami-303b1458"
+    us-east-2      = "ami-4e8fa32b"
     us-west-1      = "ami-7da94839"
     us-west-2      = "ami-69ae8259"
     eu-west-1      = "ami-6975eb1e"


### PR DESCRIPTION
When attempting to use the terraform config (0.5.0), I received the following error:
```
Error: aws_instance.nat: 1 error(s) occurred:

* aws_instance.nat: lookup: lookup failed to find 'us-east-2' in:

${lookup(var.nat_ami_map, var.region)}
``` 

I found `ami-4e8fa32b` by searching for `amzn-ami-vpc-nat-hvm-2015.03.0.x86_64`.
Note, this AMI does not appear to be owned by Amazon.

If being owned by Amazon is more important than the `2015.03` AMI version, there are `2017.09.01` AMIs out there that are provided by Amazon, I'd be happy to refresh the whole list with that set as an alternative.