### PR TITLE
Adds an IAM instance profile to PAS bucket access

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -27,3 +27,52 @@ resource "aws_iam_policy_attachment" "pas_user_policy" {
   users      = ["${aws_iam_user.iam_user.name}"]
   policy_arn = "${aws_iam_policy.ert.arn}"
 }
+
+resource "aws_iam_role" "pas_bucket_access" {
+  name = "${var.env_name}_pas_bucket_access"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "pas_bucket_access" {
+  name = "${var.env_name}_pas_bucket_access"
+  role = "${aws_iam_role.pas_bucket_access.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Action": ["s3:*"],
+    "Effect": "Allow",
+    "Resource": [
+      "${aws_s3_bucket.buildpacks_bucket.arn}",
+      "${aws_s3_bucket.buildpacks_bucket.arn}/*",
+      "${aws_s3_bucket.droplets_bucket.arn}",
+      "${aws_s3_bucket.droplets_bucket.arn}/*",
+      "${aws_s3_bucket.packages_bucket.arn}",
+      "${aws_s3_bucket.packages_bucket.arn}/*",
+      "${aws_s3_bucket.resources_bucket.arn}",
+      "${aws_s3_bucket.resources_bucket.arn}/*"
+    ]
+  }]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "pas_bucket_access" {
+  name = "${var.env_name}_pas_bucket_access"
+  role = "${aws_iam_role.pas_bucket_access.name}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -58,6 +58,10 @@ output "iam_user_secret_access_key" {
   value = "${aws_iam_access_key.iam_user_access_key.secret}"
 }
 
+output "pas_bucket_iam_instance_profile_name" {
+  value = "${aws_iam_instance_profile.pas_bucket_access.name}"
+}
+
 output "rds_address" {
   value = "${element(concat(aws_db_instance.rds.*.address, list("")), 0)}"
 }


### PR DESCRIPTION
Hi,

This PR adds an IAM instance profile that can be used to give instances access to the PAS buckets.

Let us know if you have any questions.

Thanks!
Dave and @ryanmoran 