### PR TITLE
Add a KMS master key for blobstore encryption

### DIFF
--- a/buckets.tf
+++ b/buckets.tf
@@ -33,3 +33,13 @@ resource "aws_s3_bucket" "resources_bucket" {
     Name = "Elastic Runtime S3 Resources Bucket"
   }
 }
+
+resource "aws_kms_key" "blobstore_kms_key" {
+  description             = "${var.env_name} KMS key"
+  deletion_window_in_days = 7
+}
+
+resource "aws_kms_alias" "blobstore_kms_key_alias" {
+  name          = "alias/${var.env_name}"
+  target_key_id = "${aws_kms_key.blobstore_kms_key.key_id}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,10 @@ output "pas_resources_bucket" {
   value = "${aws_s3_bucket.resources_bucket.bucket}"
 }
 
+output "blobstore_kms_key_id" {
+  value = "${aws_kms_key.blobstore_kms_key.key_id}"
+}
+
 output "ops_manager_public_ip" {
   value = "${module.ops_manager.public_ip}"
 }


### PR DESCRIPTION
Hi,

This PR adds a KMS master key that can be used for CF blobstore encryption.

Please let us know if you have any questions.

Thanks,
Dave