### PR TITLE
Add a missing Ops Manager resource count

### DIFF
--- a/ops_manager/iam.tf
+++ b/ops_manager/iam.tf
@@ -43,6 +43,7 @@ resource "aws_iam_instance_profile" "iam_instance_profile" {
 
 data "template_file" "ops_manager" {
   template = "${file("${path.module}/templates/iam_policy.json")}"
+  count    = "${var.count}"
 
   vars {
     iam_instance_profile_arn = "${aws_iam_instance_profile.iam_instance_profile.arn}"


### PR DESCRIPTION
Hi,

This PR adds a count to the ops_manager data template file to avoid errors when the ops_manager var is set to 0.

Let me know if you have any questions.

Thanks,
Dave