### PR TITLE
Changes default OpsMan instance type to `r4.large`

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "optional_ops_manager_ami" {
 }
 
 variable "ops_manager_instance_type" {
-  default = "m4.large"
+  default = "r4.large"
 }
 
 variable "rds_db_username" {


### PR DESCRIPTION
After upgrading to v0.3.0 quite a while ago, we started seeing a pattern in our CI of reduced network throughput between our Concourse workers and the OpsMan VM during file uploads. We saw some file uploads go from taking 5 minutes to 15 minutes.

In v0.3.0, the OpsManager components of these templates were split out into a separate module. At that same time, the OpsMan VM instance type was upgraded to an equivalent VM type for the latest generation (`m3.medium` -> `m4.large`).

On paper and when looking at AWS docs, these two instance types seem equivalent, and in many ways, they are. Unfortunately, the new type was causing us to see drastically reduced upload speeds to the VM.

Eventually, over a number of deployment cycles, we started to notice a pattern of failures in our CI. We connected those failures to the chosen instance type as that was the only difference we were seeing between our deployments in CI. We don't see this regression with the same OpsMan versions and ERT versions on GCP or Azure.

We spent some time today hunting down details about the networking performance of the `m4.large` type from AWS documentation. Unfortunately, AWS is a bit cagey about what exactly the performance is, only specifying "moderate".

We saw that the next step up in the `m4` tier, the `m4.xlarge` had "high" networking performance, and so attempted to use an `m4.xlarge` in a deployment to measure any performance increase. Unfortunately, we cannot tell that there was any actual difference in the performance of the `m4.large` versus the `m4.xlarge`. They both caused our file upload to take about 15 minutes.

We then saw that there was an equivalent instance type that had access to gigabit networking, the `r4.large`, and stood up an environment with that specification. Immediately, the return in networking performance was noticeable. We saw a return to 5 minute uploads.

We can continue to change the instance type for ourselves as this is already a property that is configurable via variables, but we were wondering if y'all might consider changing this to be the default instance type for the OpsMan VM as it has so many large files it needs to upload and download both to and from the client, but also to BOSH.