### PR TITLE
Optionally create versioned S3 buckets for PAS deployments

### DIFF
--- a/buckets.tf
+++ b/buckets.tf
@@ -2,6 +2,10 @@ resource "aws_s3_bucket" "buildpacks_bucket" {
   bucket        = "${var.env_name}-buildpacks-bucket"
   force_destroy = true
 
+  versioning {
+    enabled = "${var.create_versioned_pas_buckets}"
+  }
+
   tags {
     Name = "Elastic Runtime S3 Buildpacks Bucket"
   }
@@ -10,6 +14,10 @@ resource "aws_s3_bucket" "buildpacks_bucket" {
 resource "aws_s3_bucket" "droplets_bucket" {
   bucket        = "${var.env_name}-droplets-bucket"
   force_destroy = true
+
+  versioning {
+    enabled = "${var.create_versioned_pas_buckets}"
+  }
 
   tags {
     Name = "Elastic Runtime S3 Droplets Bucket"
@@ -20,6 +28,10 @@ resource "aws_s3_bucket" "packages_bucket" {
   bucket        = "${var.env_name}-packages-bucket"
   force_destroy = true
 
+  versioning {
+    enabled = "${var.create_versioned_pas_buckets}"
+  }
+
   tags {
     Name = "Elastic Runtime S3 Packages Bucket"
   }
@@ -28,6 +40,10 @@ resource "aws_s3_bucket" "packages_bucket" {
 resource "aws_s3_bucket" "resources_bucket" {
   bucket        = "${var.env_name}-resources-bucket"
   force_destroy = true
+
+  versioning {
+    enabled = "${var.create_versioned_pas_buckets}"
+  }
 
   tags {
     Name = "Elastic Runtime S3 Resources Bucket"

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,10 @@ variable "availability_zones" {
   type = "list"
 }
 
+variable "create_versioned_pas_buckets" {
+  default = false
+}
+
 variable "ops_manager_ami" {
   default = ""
 }


### PR DESCRIPTION
Hi,

This PR adds the ability to optionally turn on versioning for the S3 buckets created for PAS.

Please let us know if you have any questions.

Thanks,
Dave and @rizwanreza 