### PR TITLE
Add broader tagging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A booted ops-manager plus a whole BOATLOAD of other goodies, including:
 - An amazing NAT Box
 - SSH/HTTPS/TCP ELBs
 - An IAM User
+- Tagged resources
 
 ## Looking to setup a different IAAS
 
@@ -72,6 +73,11 @@ ssl_private_key = <<EOF
 some cert private key
 -----END RSA PRIVATE KEY-----
 EOF
+
+tags               = {
+    Team = "Dev"
+    Project = "WebApp3"
+}
 ```
 
 ## Variables
@@ -86,6 +92,7 @@ EOF
 - ssl_private_key: **(optional)** Private key for above SSL certificate. Required unless `ssl_ca_cert` is specified.
 - ssl_ca_cert: **(optional)** SSL CA certificate used to generate self-signed HTTP load balancer certificate. Required unless `ssl_cert` is specified.
 - ssl_ca_private_key: **(optional)** Private key for above SSL CA certificate. Required unless `ssl_cert` is specified.
+- tags: **(optional)** A map of AWS tags that are applied to the created resources. By default, the following tags are set: Application = Cloud Foundry, Environment = $env_name
 - vpc_cidr: **(optional)** Internal CIDR block for the AWS VPC. Defaults to 10.0.0.0/16.
 
 ## Ops Manager (optional)

--- a/buckets.tf
+++ b/buckets.tf
@@ -15,9 +15,9 @@ resource "aws_s3_bucket" "buildpacks_bucket" {
     enabled = "${var.create_versioned_pas_buckets}"
   }
 
-  tags {
-    Name = "Elastic Runtime S3 Buildpacks Bucket"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "Elastic Runtime S3 Buildpacks Bucket")
+  )}"
 }
 
 resource "aws_s3_bucket" "droplets_bucket" {
@@ -28,9 +28,9 @@ resource "aws_s3_bucket" "droplets_bucket" {
     enabled = "${var.create_versioned_pas_buckets}"
   }
 
-  tags {
-    Name = "Elastic Runtime S3 Droplets Bucket"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "Elastic Runtime S3 Droplets Bucket")
+  )}"
 }
 
 resource "aws_s3_bucket" "packages_bucket" {
@@ -41,9 +41,9 @@ resource "aws_s3_bucket" "packages_bucket" {
     enabled = "${var.create_versioned_pas_buckets}"
   }
 
-  tags {
-    Name = "Elastic Runtime S3 Packages Bucket"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "Elastic Runtime S3 Packages Bucket")
+  )}"
 }
 
 resource "aws_s3_bucket" "resources_bucket" {
@@ -54,18 +54,18 @@ resource "aws_s3_bucket" "resources_bucket" {
     enabled = "${var.create_versioned_pas_buckets}"
   }
 
-  tags {
-    Name = "Elastic Runtime S3 Resources Bucket"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "Elastic Runtime S3 Resources Bucket")
+  )}"
 }
 
 resource "aws_kms_key" "blobstore_kms_key" {
   description             = "${var.env_name} KMS key"
   deletion_window_in_days = 7
 
-  tags {
-    Name = "${var.env_name} Blobstore KMS Key"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name} Blobstore KMS Key")
+  )}"
 }
 
 resource "aws_kms_alias" "blobstore_kms_key_alias" {

--- a/dns.tf
+++ b/dns.tf
@@ -1,9 +1,9 @@
 resource "aws_route53_zone" "pcf_zone" {
   name = "${var.env_name}.${var.dns_suffix}"
 
-  tags {
-    Name = "${var.env_name}-hosted-zone"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-hosted-zone")
+  )}"
 }
 
 resource "aws_route53_record" "wildcard_sys_dns" {

--- a/elb.tf
+++ b/elb.tf
@@ -823,4 +823,6 @@ resource "aws_elb" "isoseg" {
 
   security_groups = ["${aws_security_group.isoseg_elb_security_group.id}"]
   subnets         = ["${aws_subnet.public_subnets.*.id}"]
+
+  tags = "${merge(var.tags, local.default_tags)}"
 }

--- a/internet_gateway.tf
+++ b/internet_gateway.tf
@@ -1,3 +1,4 @@
 resource "aws_internet_gateway" "ig" {
   vpc_id = "${aws_vpc.vpc.id}"
+  tags = "${merge(var.tags, local.default_tags)}"
 }

--- a/modules.tf
+++ b/modules.tf
@@ -18,4 +18,6 @@ module "ops_manager" {
   bucket_suffix = "${local.bucket_suffix}"
   instance_profile_name = "${aws_iam_instance_profile.ops_manager.name}"
   instance_profile_arn  = "${aws_iam_instance_profile.ops_manager.arn}"
+  tags          = "${var.tags}"
+  default_tags  = "${local.default_tags}"
 }

--- a/nat.tf
+++ b/nat.tf
@@ -22,12 +22,14 @@ resource "aws_instance" "nat" {
   source_dest_check      = false
   subnet_id              = "${aws_subnet.public_subnets.0.id}"
 
-  tags {
-    Name = "${var.env_name}-nat"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-nat")
+  )}"
 }
 
 resource "aws_eip" "nat_eip" {
   instance = "${aws_instance.nat.id}"
   vpc      = true
+
+  tags = "${merge(var.tags, local.default_tags)}"
 }

--- a/ops_manager/bucket.tf
+++ b/ops_manager/bucket.tf
@@ -4,7 +4,7 @@ resource "aws_s3_bucket" "ops_manager_bucket" {
 
   count = "${var.count}"
 
-  tags {
-    Name = "Ops Manager S3 Bucket"
-  }
+  tags = "${merge(var.tags, var.default_tags,
+    map("Name", "Ops Manager S3 Bucket")
+  )}"
 }

--- a/ops_manager/instance.tf
+++ b/ops_manager/instance.tf
@@ -13,7 +13,7 @@ resource "aws_instance" "ops_manager" {
     volume_size = 150
   }
 
-  tags {
-    Name = "${var.env_name}-ops-manager"
-  }
+  tags = "${merge(var.tags, var.default_tags,
+    map("Name", "${var.env_name}-ops-manager")
+  )}"
 }

--- a/ops_manager/optional_instance.tf
+++ b/ops_manager/optional_instance.tf
@@ -12,7 +12,8 @@ resource "aws_instance" "optional_ops_manager" {
     volume_size = 150
   }
 
-  tags {
-    Name = "${var.env_name}-optional-ops-manager"
-  }
+  tags = "${merge(var.tags, var.default_tags,
+    map("Name", "${var.env_name}-optional-ops-manager")
+  )}"
+
 }

--- a/ops_manager/security_group.tf
+++ b/ops_manager/security_group.tf
@@ -32,7 +32,7 @@ resource "aws_security_group" "ops_manager_security_group" {
     to_port     = 0
   }
 
-  tags {
-    Name = "${var.env_name}-ops-manager-security-group"
-  }
+  tags = "${merge(var.tags, var.default_tags,
+    map("Name", "${var.env_name}-ops-manager-security-group")
+  )}"
 }

--- a/ops_manager/variables.tf
+++ b/ops_manager/variables.tf
@@ -29,3 +29,11 @@ variable "dns_suffix" {}
 variable "zone_id" {}
 
 variable "bucket_suffix" {}
+
+variable "tags" {
+  type        = "map"
+}
+
+variable "default_tags" {
+  type        = "map"
+}

--- a/rds.tf
+++ b/rds.tf
@@ -21,4 +21,6 @@ resource "aws_db_instance" "rds" {
   apply_immediately       = true
 
   count = "${var.rds_instance_count}"
+
+  tags = "${merge(var.tags, local.default_tags)}"
 }

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -17,9 +17,9 @@ resource "aws_security_group" "nat_security_group" {
     to_port     = 0
   }
 
-  tags {
-    Name = "${var.env_name}-nat-security-group"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-nat-security-group")
+  )}"
 }
 
 resource "aws_security_group" "vms_security_group" {
@@ -41,9 +41,9 @@ resource "aws_security_group" "vms_security_group" {
     to_port     = 0
   }
 
-  tags {
-    Name = "${var.env_name}-vms-security-group"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-vms-security-group")
+  )}"
 }
 
 resource "aws_security_group" "mysql_security_group" {
@@ -65,9 +65,9 @@ resource "aws_security_group" "mysql_security_group" {
     to_port     = 0
   }
 
-  tags {
-    Name = "${var.env_name}-mysql-security-group"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-mysql-security-group")
+  )}"
 }
 
 resource "aws_security_group" "elb_security_group" {
@@ -103,9 +103,9 @@ resource "aws_security_group" "elb_security_group" {
     to_port     = 0
   }
 
-  tags {
-    Name = "${var.env_name}-elb-security-group"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-elb-security-group")
+  )}"
 }
 
 resource "aws_security_group" "isoseg_elb_security_group" {
@@ -143,9 +143,9 @@ resource "aws_security_group" "isoseg_elb_security_group" {
     to_port     = 0
   }
 
-  tags {
-    Name = "${var.env_name}-isoseg-elb-security-group"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-isoseg-elb-security-group")
+  )}"
 }
 
 resource "aws_security_group" "ssh_elb_security_group" {
@@ -167,9 +167,9 @@ resource "aws_security_group" "ssh_elb_security_group" {
     to_port     = 0
   }
 
-  tags {
-    Name = "${var.env_name}-ssh-elb-security-group"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-ssh-elb-security-group")
+  )}"
 }
 
 resource "aws_security_group" "tcp_elb_security_group" {
@@ -191,7 +191,7 @@ resource "aws_security_group" "tcp_elb_security_group" {
     to_port     = 0
   }
 
-  tags {
-    Name = "${var.env_name}-tcp-elb-security-group"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-tcp-elb-security-group")
+  )}"
 }

--- a/subnets.tf
+++ b/subnets.tf
@@ -12,9 +12,9 @@ resource "aws_subnet" "public_subnets" {
   cidr_block        = "${cidrsubnet(local.public_cidr, 2, count.index)}"
   availability_zone = "${element(var.availability_zones, count.index)}"
 
-  tags {
-    Name = "${var.env_name}-public-subnet${count.index}"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-public-subnet${count.index}")
+  )}"
 }
 
 resource "aws_subnet" "management_subnets" {
@@ -23,9 +23,9 @@ resource "aws_subnet" "management_subnets" {
   cidr_block        = "${cidrsubnet(local.management_cidr, 2, count.index)}"
   availability_zone = "${element(var.availability_zones, count.index)}"
 
-  tags {
-    Name = "${var.env_name}-management-subnet${count.index}"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-management-subnet${count.index}")
+  )}"
 }
 
 resource "aws_subnet" "pas_subnets" {
@@ -45,9 +45,9 @@ resource "aws_subnet" "services_subnets" {
   cidr_block        = "${cidrsubnet(local.services_cidr, 2, count.index)}"
   availability_zone = "${element(var.availability_zones, count.index)}"
 
-  tags {
-    Name = "${var.env_name}-services-subnet${count.index}"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-services-subnet${count.index}")
+  )}"
 }
 
 resource "aws_subnet" "rds_subnets" {
@@ -56,9 +56,9 @@ resource "aws_subnet" "rds_subnets" {
   cidr_block        = "${cidrsubnet(local.rds_cidr, 2, count.index)}"
   availability_zone = "${element(var.availability_zones, count.index)}"
 
-  tags {
-    Name = "${var.env_name}-rds-subnet${count.index}"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-rds-subnet${count.index}")
+  )}"
 }
 
 resource "aws_db_subnet_group" "rds_subnet_group" {
@@ -67,7 +67,7 @@ resource "aws_db_subnet_group" "rds_subnet_group" {
 
   subnet_ids = ["${aws_subnet.rds_subnets.*.id}"]
 
-  tags {
-    Name = "${var.env_name}-db-subnet-group"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-db-subnet-group")
+  )}"
 }

--- a/tags.tf
+++ b/tags.tf
@@ -1,0 +1,6 @@
+locals {
+  default_tags = {
+    Environment = "${var.env_name}"
+    Application = "Cloud Foundry"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -118,5 +118,6 @@ variable "create_isoseg_resources" {
 
 variable "tags" {
   type        = "map"
+  default     = {}
   description = "Key/value tags to assign to all AWS resources"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -111,3 +111,12 @@ variable "create_isoseg_resources" {
   default     = "0"
   description = "Optionally create a LB and DNS entries for a single isolation segment. Valid values are 0 or 1."
 }
+
+/*******
+* Tags *
+********/
+
+variable "tags" {
+  type        = "map"
+  description = "Key/value tags to assign to all AWS resources"
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -3,7 +3,7 @@ resource "aws_vpc" "vpc" {
   instance_tenancy     = "default"
   enable_dns_hostnames = true
 
-  tags {
-    Name = "${var.env_name}-vpc"
-  }
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "${var.env_name}-vpc")
+  )}"
 }


### PR DESCRIPTION
Add broader tagging support with support for default tags
along with user specified tags. This allows customers to utilize
AWS tagging best practices and enables them to track deployments
by environment, team, release, etc. These tags can be used then
for tracking billing by environment - for showback internally -
or for simply tracking resource usage across teams and environments.