### PR TITLE
Add `iaas` output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
+output "iaas" {
+  value = "aws"
+}
+
 output "ops_manager_bucket" {
   value = "${module.ops_manager.bucket}"
 }


### PR DESCRIPTION
- Makes it easier for our scripts to perform terraform actions given a
  terraform statefile
- Right now we have to explicitly pass an IAAS env var to our scripts in
  CI in addition to the statefile