### PR TITLE
Change RDS instance type

### DIFF
--- a/rds.tf
+++ b/rds.tf
@@ -6,8 +6,8 @@ resource "random_string" "rds_password" {
 resource "aws_db_instance" "rds" {
   allocated_storage      = 100
   instance_class         = "${var.rds_instance_class}"
-  engine                 = "mysql"
-  engine_version         = "5.6.35"
+  engine                 = "mariadb"
+  engine_version         = "10.1.31"
   identifier             = "${var.env_name}"
   username               = "${var.rds_db_username}"
   password               = "${random_string.rds_password.result}"


### PR DESCRIPTION
This PR fixes two issues:

1. The App Autoscaler Smoke Tests rely on the DB being of type `mariadb`. DBs of type `mysql` cause the smoke tests to fail reliably.
1. Credhub requires TLS v1.2. The version of `mysql` that was created with the original scripts were compiled with YaSSL, not OpenSSL, and didn't support TLS v1.2. This bumps the version of `mariadb` to a version new enough so that it was compiled against OpenSSL.

This was tested against an install of PAS 2.1.3 successfully.