### PR TITLE
Remove **tags** from the **nat_eip** resource

### DIFF
--- a/nat.tf
+++ b/nat.tf
@@ -30,6 +30,4 @@ resource "aws_instance" "nat" {
 resource "aws_eip" "nat_eip" {
   instance = "${aws_instance.nat.id}"
   vpc      = true
-
-  tags = "${merge(var.tags, local.default_tags)}"
 }


### PR DESCRIPTION
The [aws_eip resource type](https://www.terraform.io/docs/providers/aws/d/eip.html) doesn't support tags. When you attempt to include them you get this error:
```
Error: aws_eip.nat_eip: : invalid or unknown key: tags
```
For reference, here is our terraform version info:
```
$ terraform version
Terraform v0.11.7
+ provider.aws v1.3.0
+ provider.random v1.1.0
+ provider.template v1.0.0
+ provider.tls v1.0.1
```

Let me know if you have any questions.
Dave