### PR TITLE
Fix outputs

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -14,14 +14,6 @@ data "aws_route53_zone" "pcf_zone" {
   name = "${var.hosted_zone}"
 }
 
-output "zone_id" {
-  value = "${local.zone_id}"
-}
-
-output "name_servers" {
-  value = "${join(",", flatten(concat(data.aws_route53_zone.pcf_zone.*.name_servers, list(list("")))))}"
-}
-
 resource "aws_route53_zone" "pcf_zone" {
   count = "${var.hosted_zone == "" ? 1 : 0}"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,7 +39,7 @@ output "optional_ops_manager_dns" {
 }
 
 output "env_dns_zone_name_servers" {
-  value = ["${split(",", local.name_servers)}"]
+  value = ["${compact(split(",", local.name_servers))}"]
 }
 
 output "sys_domain" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -241,7 +241,7 @@ output "isoseg_ssl_private_key" {
 }
 
 output "dns_zone_id" {
-  value = "${aws_route53_zone.pcf_zone.id}"
+  value = "${local.zone_id}"
 }
 
 output "ops_manager_ip" {


### PR DESCRIPTION
- Remove empty DNS name server list entries (as it broke our tooling that parsed the list)
- Convert dns_zone_id output to use local.zone_id to eliminate this warning: `Warning: output "dns_zone_id": must use splat syntax to access aws_route53_zone.pcf_zone attribute "id", because it has "count" set; use aws_route53_zone.pcf_zone.*.id to obtain a list of the attributes across all instances`

Let me know if you have any questions.
Dave