### PR TITLE
Add optional backup buckets for PAS

### DIFF
--- a/buckets.tf
+++ b/buckets.tf
@@ -72,3 +72,47 @@ resource "aws_kms_alias" "blobstore_kms_key_alias" {
   name          = "alias/${var.env_name}"
   target_key_id = "${aws_kms_key.blobstore_kms_key.key_id}"
 }
+
+resource "aws_s3_bucket" "buildpacks_backup_bucket" {
+  bucket        = "${var.env_name}-buildpacks-backup-bucket-${local.bucket_suffix}"
+  force_destroy = true
+
+  count = "${var.create_backup_pas_buckets ? 1 : 0}"
+
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "Elastic Runtime S3 Buildpacks Backup Bucket")
+  )}"
+}
+
+resource "aws_s3_bucket" "droplets_backup_bucket" {
+  bucket        = "${var.env_name}-droplets-backup-bucket-${local.bucket_suffix}"
+  force_destroy = true
+
+  count = "${var.create_backup_pas_buckets ? 1 : 0}"
+
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "Elastic Runtime S3 Droplets Backup Bucket")
+  )}"
+}
+
+resource "aws_s3_bucket" "packages_backup_bucket" {
+  bucket        = "${var.env_name}-packages-backup-bucket-${local.bucket_suffix}"
+  force_destroy = true
+
+  count = "${var.create_backup_pas_buckets ? 1 : 0}"
+
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "Elastic Runtime S3 Packages Backup Bucket")
+  )}"
+}
+
+resource "aws_s3_bucket" "resources_backup_bucket" {
+  bucket        = "${var.env_name}-resources-backup-bucket-${local.bucket_suffix}"
+  force_destroy = true
+
+  count = "${var.create_backup_pas_buckets ? 1 : 0}"
+
+  tags = "${merge(var.tags, local.default_tags,
+    map("Name", "Elastic Runtime S3 Resources Backup Bucket")
+  )}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,10 @@ variable "create_versioned_pas_buckets" {
   default = false
 }
 
+variable "create_backup_pas_buckets" {
+  default = false
+}
+
 variable "ops_manager_ami" {
   default = ""
 }


### PR DESCRIPTION
This PR adds 4 optional backup buckets for the 4 existing PAS blobstore buckets. They are intended to be usable by the BBR process when backing up unversioned S3 buckets being used as the CF blobstore.

Let us know if you have any questions.
Thanks,
Dave and @michelleheh 