### PR TITLE
Add IAM user access to the PAS backup buckets

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -113,10 +113,20 @@ data "template_file" "pas_backup_bucket_policy" {
   count = "${var.create_backup_pas_buckets ? 1 : 0}"
 }
 
+resource "aws_iam_policy" "pas_backup_bucket_policy" {
+  name   = "${var.env_name}_pas_backup_bucket_policy"
+  policy = "${data.template_file.pas_backup_bucket_policy.rendered}"
+}
+
 resource "aws_iam_role_policy" "pas_backup_bucket_access" {
   name   = "${var.env_name}_pas_backup_bucket_access"
   role   = "${aws_iam_role.pas_bucket_access.id}"
   policy = "${data.template_file.pas_backup_bucket_policy.rendered}"
 
   count = "${var.create_backup_pas_buckets ? 1 : 0}"
+}
+
+resource "aws_iam_user_policy_attachment" "pas_backup_bucket_access" {
+  user       = "${aws_iam_user.ops_manager.name}"
+  policy_arn = "${aws_iam_policy.pas_backup_bucket_policy.arn}"
 }


### PR DESCRIPTION
Hi,

This PR allows the ops_manager IAM user to access the PAS backup S3 buckets.

Please let me know if you have any questions.

Thanks,
Dave