### PR TITLE
Add variable to deploy Ops Manager to private subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ tags               = {
 - optional_ops_manager: **(default: false)** Set to true if you want an additional Ops Manager (useful for testing upgrades)
 - optional_ops_manager_ami: **(optional)**  Additional Ops Manager AMI, get the right AMI according to your region from the AWS guide downloaded from [Pivotal Network](https://network.pivotal.io/products/ops-manager)
 - ops_manager_instance_type: **(default: m4.large)** Ops Manager instance type
+- ops_manager_private: **(default: false)** Set to true if you want Ops Manager deployed in a private subnet instead of a public subnet
 
 ## RDS (optional)
 - rds_instance_count: **(default: 0)** Whether or not you would like an RDS for your deployment

--- a/modules.tf
+++ b/modules.tf
@@ -11,6 +11,7 @@ module "ops_manager" {
   instance_type             = "${var.ops_manager_instance_type}"
   private                   = "${var.ops_manager_private}"
   vpc_id                    = "${aws_vpc.vpc.id}"
+  vpc_cidr                  = "${var.vpc_cidr}"
   dns_suffix                = "${var.dns_suffix}"
   zone_id                   = "${local.zone_id}"
   iam_ops_manager_user_name = "${aws_iam_user.ops_manager.name}"

--- a/modules.tf
+++ b/modules.tf
@@ -3,12 +3,13 @@ module "ops_manager" {
 
   count          = "${var.ops_manager ? 1 : 0}"
   optional_count = "${var.optional_ops_manager ? 1 : 0}"
+  subnet_id      = "${var.ops_manager_private ? aws_subnet.management_subnets.0.id : aws_subnet.public_subnets.0.id}"
 
   env_name                  = "${var.env_name}"
   ami                       = "${var.ops_manager_ami}"
   optional_ami              = "${var.optional_ops_manager_ami}"
   instance_type             = "${var.ops_manager_instance_type}"
-  subnet_id                 = "${aws_subnet.public_subnets.0.id}"
+  private                   = "${var.ops_manager_private}"
   vpc_id                    = "${aws_vpc.vpc.id}"
   dns_suffix                = "${var.dns_suffix}"
   zone_id                   = "${local.zone_id}"

--- a/ops_manager/dns.tf
+++ b/ops_manager/dns.tf
@@ -5,7 +5,7 @@ resource "aws_route53_record" "ops_manager" {
   ttl     = 300
   count   = "${var.count}"
 
-  records = ["${aws_eip.ops_manager.public_ip}"]
+  records = ["${coalesce(join("", aws_eip.ops_manager.*.public_ip), aws_instance.ops_manager.private_ip)}"]
 }
 
 resource "aws_route53_record" "optional_ops_manager" {
@@ -15,5 +15,5 @@ resource "aws_route53_record" "optional_ops_manager" {
   ttl     = 300
   count   = "${var.optional_count}"
 
-  records = ["${aws_eip.optional_ops_manager.public_ip}"]
+  records = ["${coalesce(join("", aws_eip.optional_ops_manager.*.public_ip), aws_instance.optional_ops_manager.private_ip)}"]
 }

--- a/ops_manager/eip.tf
+++ b/ops_manager/eip.tf
@@ -1,11 +1,11 @@
 resource "aws_eip" "ops_manager" {
   instance = "${aws_instance.ops_manager.id}"
-  count    = "${var.count}"
+  count    = "${var.private ? 0 : var.count}"
   vpc      = true
 }
 
 resource "aws_eip" "optional_ops_manager" {
   instance = "${aws_instance.optional_ops_manager.id}"
-  count    = "${var.optional_count}"
+  count    = "${var.private ? 0 : var.optional_count}"
   vpc      = true
 }

--- a/ops_manager/security_group.tf
+++ b/ops_manager/security_group.tf
@@ -5,28 +5,28 @@ resource "aws_security_group" "ops_manager_security_group" {
   count       = "${var.count}"
 
   ingress {
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.private ? "10.0.0.0/8" : "0.0.0.0/0"}"]
     protocol    = "tcp"
     from_port   = 22
     to_port     = 22
   }
 
   ingress {
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.private ? "10.0.0.0/8" : "0.0.0.0/0"}"]
     protocol    = "tcp"
     from_port   = 80
     to_port     = 80
   }
 
   ingress {
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.private ? "10.0.0.0/8" : "0.0.0.0/0"}"]
     protocol    = "tcp"
     from_port   = 443
     to_port     = 443
   }
 
   egress {
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.private ? "10.0.0.0/8" : "0.0.0.0/0"}"]
     protocol    = "-1"
     from_port   = 0
     to_port     = 0

--- a/ops_manager/security_group.tf
+++ b/ops_manager/security_group.tf
@@ -5,28 +5,28 @@ resource "aws_security_group" "ops_manager_security_group" {
   count       = "${var.count}"
 
   ingress {
-    cidr_blocks = ["${var.private ? "10.0.0.0/8" : "0.0.0.0/0"}"]
+    cidr_blocks = ["${var.private ? var.vpc_cidr : "0.0.0.0/0"}"]
     protocol    = "tcp"
     from_port   = 22
     to_port     = 22
   }
 
   ingress {
-    cidr_blocks = ["${var.private ? "10.0.0.0/8" : "0.0.0.0/0"}"]
+    cidr_blocks = ["${var.private ? var.vpc_cidr : "0.0.0.0/0"}"]
     protocol    = "tcp"
     from_port   = 80
     to_port     = 80
   }
 
   ingress {
-    cidr_blocks = ["${var.private ? "10.0.0.0/8" : "0.0.0.0/0"}"]
+    cidr_blocks = ["${var.private ? var.vpc_cidr : "0.0.0.0/0"}"]
     protocol    = "tcp"
     from_port   = 443
     to_port     = 443
   }
 
   egress {
-    cidr_blocks = ["${var.private ? "10.0.0.0/8" : "0.0.0.0/0"}"]
+    cidr_blocks = ["${var.private ? var.vpc_cidr : "0.0.0.0/0"}"]
     protocol    = "-1"
     from_port   = 0
     to_port     = 0

--- a/ops_manager/variables.tf
+++ b/ops_manager/variables.tf
@@ -16,6 +16,8 @@ variable "subnet_id" {}
 
 variable "vpc_id" {}
 
+variable "vpc_cidr" {}
+
 variable "iam_ops_manager_user_name" {}
 
 variable "iam_ops_manager_role_name" {}

--- a/ops_manager/variables.tf
+++ b/ops_manager/variables.tf
@@ -2,6 +2,8 @@ variable "count" {}
 
 variable "optional_count" {}
 
+variable "private" {}
+
 variable "env_name" {}
 
 variable "ami" {}

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,11 @@ variable "ops_manager_instance_type" {
   default = "r4.large"
 }
 
+variable "ops_manager_private" {
+  default = false
+  description = "If true, the Ops Manager will be colocated with the BOSH director on the management subnet instead of on the public subnet"
+}
+
 variable "rds_db_username" {
   default = "admin"
 }


### PR DESCRIPTION
### Impetus

Some customers want their Ops Manager to be deployed in a private subnet to restrict its access from the outside world. `terraforming-aws` creates 4 subnets per AZ in the VPC: `public`, `management`, `pas`, and `services`. In these cases, the Ops Manager should be located in the `management` subnet, as that's where the BOSH director should be deployed

### Implementation

This PR addresses that concern by adding a new optional variable called `ops_manager_private`. Its default value is `false`, but when `true`, it takes the following steps:

1. Skips creating elastic IPs
1. Assigns the _private_ IP of the Ops Manager to the route53 A record in the hosted zone
1. Sets the Ops Manager's security group to only allow ingress from the VPC CIDR range
1. Sets the Ops Manager's subnet to the first AZ's `management` subnet, rather than the first AZ's `public` subnet.