### PR TITLE
Add tags for addresses.

### DIFF
--- a/ops_manager/eip.tf
+++ b/ops_manager/eip.tf
@@ -2,10 +2,18 @@ resource "aws_eip" "ops_manager" {
   instance = "${aws_instance.ops_manager.id}"
   count    = "${var.private ? 0 : var.count}"
   vpc      = true
+
+  tags = "${merge(var.tags, var.default_tags,
+    map("Name", "${var.env_name}-om-eip")
+  )}"
 }
 
 resource "aws_eip" "optional_ops_manager" {
   instance = "${aws_instance.optional_ops_manager.id}"
   count    = "${var.private ? 0 : var.optional_count}"
   vpc      = true
+
+  tags = "${merge(var.tags, var.default_tags,
+    map("Name", "${var.env_name}-optional-om-eip")
+  )}"
 }


### PR DESCRIPTION
`leftovers` wants to be able to delete addresses _only_ when they can be filtered using an environment name. Terraform supports tagging this resource so we should use them in the template!