### PR TITLE
Reference Opsman Subnet ID by index instead of using element.

### DIFF
--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 locals {
-  ops_man_subnet_id = "${var.ops_manager_private ? element(module.infra.infrastructure_subnet_ids, 0) : element(module.infra.public_subnet_ids, 0)}"
+  ops_man_subnet_id = "${var.ops_manager_private ? module.infra.infrastructure_subnet_ids.0 : module.infra.public_subnet_ids.0}"
 
   bucket_suffix = "${random_integer.bucket.result}"
 


### PR DESCRIPTION
- Element will throw an error if passed an empty list.

We would like this change merged in as our automation will attempt to do a terraform destroy initially, this will error out here since we will pass an empty list to the `element` call.

I'm not sure if referencing by index causes any other unintended issues, but works for our automation.

Thanks!