### PR TITLE
Change wildcard to specific route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.tfstate
 *.tfvars
 *.tfplan
+*.pem

--- a/modules/pks/dns.tf
+++ b/modules/pks/dns.tf
@@ -2,13 +2,16 @@ locals {
   use_route53 = "${var.region == "us-gov-west-1" ? 0 : 1}"
 }
 
-resource "aws_route53_record" "wildcard_sys_dns" {
+resource "aws_route53_record" "pks_api_dns" {
   zone_id = "${var.zone_id}"
-  name    = "*.pks.${var.env_name}.${var.dns_suffix}"
-  type    = "CNAME"
-  ttl     = 300
+  name    = "api.pks.${var.env_name}.${var.dns_suffix}"
+  type    = "A"
 
-  records = ["${aws_elb.pks_api_elb.dns_name}"]
+  alias {
+    name                   = "${aws_elb.pks_api_elb.dns_name}"
+    zone_id                = "${aws_elb.pks_api_elb.zone_id}"
+    evaluate_target_health = true
+  }
 
   count = "${local.use_route53 ? 1 : 0}"
 }


### PR DESCRIPTION
This seemed weird to me, since the PKS endpoint is not a wildcard, and the resulting k8s cluster routes aren't tied to a single go-router like in PAS.  This changes that wildcard entry into a specific entry so that you can easily target the `pks` cli to just `pks.${var.env_name}.${var.dns_suffix}`, so your opsman would be at `pcf.${var.env_name}.${var.dns_suffix}` and this would be where you'd target pks towards.