### PR TITLE
Use Ops manager dns entry instead of EIP

### DIFF
--- a/scripts/configure-director
+++ b/scripts/configure-director
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 authenticate_om() {
-  export OM_TARGET="https://$(terraform output ops_manager_public_ip)"
+  export OM_TARGET="https://$(terraform output ops_manager_dns)"
   export OM_USERNAME="admin"
   export OM_PASSWORD="$1"
 }

--- a/scripts/configure-product
+++ b/scripts/configure-product
@@ -1,7 +1,7 @@
 #!/bin/bash -exu
 
 authenticate_om() {
-  export OM_TARGET="https://$(terraform output ops_manager_public_ip)"
+  export OM_TARGET="https://$(terraform output ops_manager_dns)"
   export OM_USERNAME="admin"
   export OM_PASSWORD="$1"
 }

--- a/scripts/delete-installation
+++ b/scripts/delete-installation
@@ -1,7 +1,7 @@
 #!/bin/bash -exu
 
 authenticate_om() {
-  export OM_TARGET="https://$(terraform output ops_manager_public_ip)"
+  export OM_TARGET="https://$(terraform output ops_manager_dns)"
   export OM_USERNAME="admin"
   export OM_PASSWORD="$1"
 }


### PR DESCRIPTION
If you configure the director with `ops_manager_public_ip` then it gets hit with the permanent issue when setting up Ops Manager without using a fully qualified DNS entry.

If you go and try to log in again, you'll hit:

![image](https://user-images.githubusercontent.com/1326605/48218844-d4b41900-e358-11e8-8364-a51caa82dc3c.png)

I'd recommend either "splitting" these scripts into a CI only use and hiding them elsewhere, or changing to using the DNS name.