### PR TITLE
Bugfix: Gov Cloud Route 53

### DIFF
--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -19,6 +19,8 @@ locals {
   }
 
   actual_tags = "${merge(var.tags, local.default_tags)}"
+
+  use_route53 = "${var.region == "us-gov-west-1" ? false : true}"
 }
 
 resource "random_integer" "bucket" {
@@ -60,6 +62,7 @@ module "ops_manager" {
   bucket_suffix             = "${local.bucket_suffix}"
 
   tags                      = "${local.actual_tags}"
+  use_route53              = "${local.use_route53}"
 }
 
 module "pas_certs" {
@@ -104,6 +107,7 @@ module "pas" {
   bucket_suffix                = "${local.bucket_suffix}"
   zone_id                      = "${module.infra.zone_id}"
   dns_suffix                   = "${var.dns_suffix}"
+  use_route53   = "${local.use_route53}"
 
   create_backup_pas_buckets    = "${var.create_backup_pas_buckets}"
   create_versioned_pas_buckets = "${var.create_versioned_pas_buckets}"

--- a/terraforming-pks/main.tf
+++ b/terraforming-pks/main.tf
@@ -20,7 +20,7 @@ locals {
 
   actual_tags = "${merge(var.tags, local.default_tags)}"
 
-  use_route53 = "${var.region != "us-gov-west-1" ? var.use_route53 : false}"
+  use_route53 = "${var.region == "us-gov-west-1" ? false : true}"
 }
 
 resource "random_integer" "bucket" {

--- a/terraforming-pks/variables.tf
+++ b/terraforming-pks/variables.tf
@@ -77,10 +77,6 @@ variable "ssl_ca_private_key" {
   description = "the contents of a CA private key to be used to sign the generated PKS API certificate, optional if `ssl_cert` is provided"
   default     = ""
 }
-variable "use_route53" {
-  description = "true will create Route53 resources, will skip their creation otherwise."
-  default = true
-}
 
 /******
 * RDS *


### PR DESCRIPTION
Removes variable due to issue with how hashicorp imports variables (if we put this back into the `main.tf` it works again, not sure how you want to handle that)  

Adds in missing PAS variables!  D'oh

Due to the way Hashicorp does imports into the `main.tf` file, if you try to use this for a govcloud account you'll get an error:

```
Error: Error asking for user input: 1 error(s) occurred:

* local.use_route53: local.use_route53: 1:43: unknown variable accessed: var.use_route53 in:

${var.region == "us-gov-west-1" ? false : var.use_route53}
```

So instead, just remove the `var.use_route53` entirely, although it can be added back in it would **have** to be in the `main.tf` to avoid an import issue.