### PR TITLE
Allow all outbound traffic no matter what

### DIFF
--- a/modules/ops_manager/security_group.tf
+++ b/modules/ops_manager/security_group.tf
@@ -26,7 +26,7 @@ resource "aws_security_group" "ops_manager_security_group" {
   }
 
   egress {
-    cidr_blocks = ["${var.private ? var.vpc_cidr : "0.0.0.0/0"}"]
+    cidr_blocks = ["0.0.0.0/0"]
     protocol    = "-1"
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
This should resolve https://github.com/pivotal-cf/terraforming-aws/issues/85 by allowing outbound traffic even when ops manager is on a private subnet.