### PR TITLE
Update dns.tf

### DIFF
--- a/modules/infra/dns.tf
+++ b/modules/infra/dns.tf
@@ -26,7 +26,7 @@ resource "aws_route53_zone" "pcf_zone" {
 }
 
 resource "aws_route53_record" "name_servers" {
-  count = "${local.use_route53 ? local.hosted_zone_count : 0}"
+  count = "${local.use_route53 ? (1 - local.hosted_zone_count) : 0}"
 
   zone_id = "${local.zone_id}"
   name    = "${var.env_name}.${var.dns_suffix}"


### PR DESCRIPTION
Do not create nameservers in pre-existing hosted zones.

This was a bugfix in my fork that didn't make it in a PR back to master.

Resolves issue with additional `NS` entries being made into Route 53, preventing access for existing hosted zones.