### PR TITLE
output reserved IP for subnets

### DIFF
--- a/modules/infra/networking.tf
+++ b/modules/infra/networking.tf
@@ -18,6 +18,16 @@ data "template_file" "infrastructure_subnet_gateways" {
   }
 }
 
+data "template_file" "infrastructure_subnet_reserved_ips" {
+  # Render the template once for each availability zone
+  count    = "${length(var.availability_zones)}"
+  template = "$${reserved_ips}"
+
+  vars {
+    reserved_ips = "${cidrhost(element(aws_subnet.infrastructure_subnets.*.cidr_block, count.index), 0)}-${cidrhost(element(aws_subnet.infrastructure_subnets.*.cidr_block, count.index), 3)}"
+  }
+}
+
 resource "aws_route_table_association" "route_infrastructure_subnets" {
   count          = "${length(var.availability_zones)}"
   subnet_id      = "${element(aws_subnet.infrastructure_subnets.*.id, count.index)}"

--- a/modules/infra/outputs.tf
+++ b/modules/infra/outputs.tf
@@ -50,6 +50,10 @@ output "infrastructure_subnet_gateways" {
   value = ["${data.template_file.infrastructure_subnet_gateways.*.rendered}"]
 }
 
+output "infrastructure_subnet_reserved_ips" {
+  value = ["${data.template_file.infrastructure_subnet_reserved_ips.*.rendered}"]
+}
+
 output "aws_lb_interface_endpoint_ips" {
   value = "${data.aws_network_interface.lb_endpoints.*.private_ip}"
 }

--- a/modules/pas/outputs.tf
+++ b/modules/pas/outputs.tf
@@ -20,6 +20,10 @@ output "services_subnet_ids" {
   value = ["${aws_subnet.services_subnets.*.id}"]
 }
 
+output "pas_subnet_reserved_ips" {
+  value = ["${data.template_file.pas_subnet_reserved_ips.*.rendered}"]
+}
+
 output "services_subnet_availability_zones" {
   value = ["${aws_subnet.services_subnets.*.availability_zone}"]
 }
@@ -30,6 +34,10 @@ output "services_subnet_cidrs" {
 
 output "services_subnet_gateways" {
   value = ["${data.template_file.services_subnet_gateways.*.rendered}"]
+}
+
+output "services_subnet_reserved_ips" {
+  value = ["${data.template_file.services_subnet_reserved_ips.*.rendered}"]
 }
 
 output "pas_bucket_iam_instance_profile_name" {

--- a/modules/pas/subnets.tf
+++ b/modules/pas/subnets.tf
@@ -19,6 +19,16 @@ data "template_file" "pas_subnet_gateways" {
   template = "$${gateway}"
 }
 
+data "template_file" "pas_subnet_reserved_ips" {
+  # Render the template once for each availability zone
+  count    = "${length(var.availability_zones)}"
+  template = "$${reserved_ips}"
+
+  vars {
+    reserved_ips = "${cidrhost(element(aws_subnet.pas_subnets.*.cidr_block, count.index), 0)}-${cidrhost(element(aws_subnet.pas_subnets.*.cidr_block, count.index), 3)}"
+  }
+}
+
 resource "aws_route_table_association" "route_pas_subnets" {
   count          = "${length(var.availability_zones)}"
   subnet_id      = "${element(aws_subnet.pas_subnets.*.id, count.index)}"
@@ -42,6 +52,16 @@ data "template_file" "services_subnet_gateways" {
   # Render the template once for each availability zone
   count    = "${length(var.availability_zones)}"
   template = "$${gateway}"
+}
+
+data "template_file" "services_subnet_reserved_ips" {
+  # Render the template once for each availability zone
+  count    = "${length(var.availability_zones)}"
+  template = "$${reserved_ips}"
+
+  vars {
+    reserved_ips = "${cidrhost(element(aws_subnet.services_subnets.*.cidr_block, count.index), 0)}-${cidrhost(element(aws_subnet.services_subnets.*.cidr_block, count.index), 3)}"
+  }
 }
 
 resource "aws_route_table_association" "route_services_subnets" {

--- a/terraforming-pas/outputs.tf
+++ b/terraforming-pas/outputs.tf
@@ -160,6 +160,10 @@ output "infrastructure_subnet_gateways" {
   value = "${module.infra.infrastructure_subnet_gateways}"
 }
 
+output "infrastructure_subnet_reserved_ips" {
+  value = "${module.infra.infrastructure_subnet_reserved_ips}"
+}
+
 output "pas_subnet_ids" {
   value = "${module.pas.pas_subnet_ids}"
 }
@@ -180,6 +184,10 @@ output "pas_subnet_gateways" {
   value = "${module.pas.pas_subnet_gateways}"
 }
 
+output "pas_subnet_reserved_ips" {
+  value = "${module.pas.pas_subnet_reserved_ips}"
+}
+
 output "services_subnet_ids" {
   value = "${module.pas.services_subnet_ids}"
 }
@@ -198,6 +206,10 @@ output "services_subnet_cidrs" {
 
 output "services_subnet_gateways" {
   value = "${module.pas.services_subnet_gateways}"
+}
+
+output "services_subnet_reserved_ips" {
+  value = "${module.pas.services_subnet_reserved_ips}"
 }
 
 output "vpc_id" {


### PR DESCRIPTION
**WHY?**
With use of terraforming-aws for infrastructure paving, one important part which is missing from terraform output file is reserved IPs for each subnet.

As per [AWS VPC documentation](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html#vpc-sizing-ipv4), First 4 IPs are reserved in each subnet.
```
The first four IP addresses and the last IP address in each subnet CIDR block are not available for you to use, and cannot be assigned to an instance. For example, in a subnet with CIDR block 10.0.0.0/24, the following five IP addresses are reserved:

10.0.0.0: Network address.

10.0.0.1: Reserved by AWS for the VPC router.

10.0.0.2: Reserved by AWS. The IP address of the DNS server is always the base of the VPC network range plus two; however, we also reserve the base of each subnet range plus two. For VPCs with multiple CIDR blocks, the IP address of the DNS server is located in the primary CIDR. For more information, see Amazon DNS Server.

10.0.0.3: Reserved by AWS for future use.

10.0.0.255: Network broadcast address. We do not support broadcast in a VPC, therefore we reserve this address.
```

**CHANGES**

- Get reserved ip range by using ``cidrhost`` function for subnets.

**Output will look something like this:**
```
infrastructure_subnet_cidrs = [
    10.0.16.0/28,
    10.0.16.16/28,
    10.0.16.32/28
]
infrastructure_subnet_reserved_ips = [
    10.0.16.0-10.0.16.3,
    10.0.16.16-10.0.16.19,
    10.0.16.32-10.0.16.35
]
```
Similarly for other subnets.

**How this was used?**
This was used to automate opsmanager deployment by fetching properties like
```
      "name": "infrastructure",
      "service_network": false,
      "subnets": [
        {
          "iaas_identifier": ((infrastructure_subnet_ids_az1)),
          "cidr": ((infrastructure_subnet_cidrs_az1)),
          "dns": "8.8.8.8",
          "gateway": ((infrastructure_subnet_gateways_az1)),
          "reserved_ip_ranges": ((infrastructure_subnet_reserved_ips_z1)),
          "availability_zone_names": [((az1))]
        }
      ]
```
reference: [config link](https://github.com/ronakbanka/platform-automation/blob/master/aws/products/director.yml#L113)