### PR TITLE
Small changes dns ci gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,9 @@
 *.tfplan
 .idea
 .idea/*
+*.pem
 *.pivotal
+*stemcell*.tgz
+*.generated.yml
+OpsManager*onAWS.yml
 om.key

--- a/ci/assets/template/director-config.yml
+++ b/ci/assets/template/director-config.yml
@@ -13,6 +13,7 @@ properties-configuration:
   iaas_configuration:
     access_key_id: {{.ops_manager_iam_user_access_key}}
     secret_access_key: {{.ops_manager_iam_user_secret_key}}
+    iam_instance_profile: {{.ops_manager_iam_instance_profile_name}}
     vpc_id: {{.vpc_id}}
     security_group: {{.vms_security_group_id}}
     key_pair_name: {{.ops_manager_ssh_public_key_name}}

--- a/modules/infra/networking.tf
+++ b/modules/infra/networking.tf
@@ -46,7 +46,14 @@ resource "aws_subnet" "public_subnets" {
   cidr_block        = "${cidrsubnet(local.public_cidr, 2, count.index)}"
   availability_zone = "${element(var.availability_zones, count.index)}"
 
-  tags = "${merge(var.tags, map("Name", "${var.env_name}-public-subnet${count.index}"))}"
+  tags = "${merge(var.tags, map("Name", "${var.env_name}-public-subnet${count.index}"), 
+      map("kubernetes.io/role/elb", "1"), 
+      map("SubnetType", "Utility"))}"
+
+  # Ignore additional tags that are added for specifying clusters.
+  lifecycle {
+    ignore_changes = ["tags.%", "tags.kubernetes"]
+  }
 }
 
 resource "aws_route_table_association" "route_public_subnets" {

--- a/modules/pas/dns.tf
+++ b/modules/pas/dns.tf
@@ -6,38 +6,50 @@ resource "aws_route53_record" "wildcard_sys_dns" {
   count   = "${local.use_route53 ? 1 : 0}"
   zone_id = "${var.zone_id}"
   name    = "*.sys.${var.env_name}.${var.dns_suffix}"
-  type    = "CNAME"
-  ttl     = 300
+  type    = "A"
 
-  records = ["${aws_lb.web.dns_name}"]
+  alias {
+    name                   = "${aws_lb.web.dns_name}"
+    zone_id                = "${aws_lb.web.zone_id}"
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "wildcard_apps_dns" {
   count   = "${local.use_route53 ? 1 : 0}"
   zone_id = "${var.zone_id}"
   name    = "*.apps.${var.env_name}.${var.dns_suffix}"
-  type    = "CNAME"
-  ttl     = 300
+  type    = "A"
 
-  records = ["${aws_lb.web.dns_name}"]
+  alias {
+    name                   = "${aws_lb.web.dns_name}"
+    zone_id                = "${aws_lb.web.zone_id}"
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "ssh" {
   count   = "${local.use_route53 ? 1 : 0}"
   zone_id = "${var.zone_id}"
   name    = "ssh.sys.${var.env_name}.${var.dns_suffix}"
-  type    = "CNAME"
-  ttl     = 300
+  type    = "A"
 
-  records = ["${aws_lb.ssh.dns_name}"]
+  alias {
+    name                   = "${aws_lb.ssh.dns_name}"
+    zone_id                = "${aws_lb.ssh.zone_id}"
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "tcp" {
   count   = "${local.use_route53 ? 1 : 0}"
   zone_id = "${var.zone_id}"
   name    = "tcp.${var.env_name}.${var.dns_suffix}"
-  type    = "CNAME"
-  ttl     = 300
+  type    = "A"
 
-  records = ["${aws_lb.tcp.dns_name}"]
+  alias {
+    name                   = "${aws_lb.tcp.dns_name}"
+    zone_id                = "${aws_lb.tcp.zone_id}"
+    evaluate_target_health = true
+  }
 }

--- a/modules/pks/networking.tf
+++ b/modules/pks/networking.tf
@@ -31,7 +31,14 @@ resource "aws_subnet" "services_subnets" {
   cidr_block        = "${cidrsubnet(local.pks_services_cidr, 2, count.index)}"
   availability_zone = "${element(var.availability_zones, count.index)}"
 
-  tags = "${merge(var.tags, map("Name", "${var.env_name}-pks-services-subnet${count.index}"))}"
+  tags = "${merge(var.tags, map("Name", "${var.env_name}-pks-services-subnet${count.index}"), 
+      map("kubernetes.io/role/internal-elb", "1"), 
+      map("SubnetType", "Private"))}"
+
+  # Ignore additional tags that are added for specifying clusters.
+  lifecycle {
+    ignore_changes = ["tags.%", "tags.kubernetes"]
+  }
 }
 
 data "template_file" "services_subnet_gateways" {

--- a/terraforming-control-plane/.gitignore
+++ b/terraforming-control-plane/.gitignore
@@ -1,0 +1,3 @@
+control-plane-*.yml
+*.tgz
+*secrets.yml

--- a/terraforming-control-plane/db/create_databases.sh
+++ b/terraforming-control-plane/db/create_databases.sh
@@ -2,6 +2,8 @@
 
 set -euox pipefail
 
+command -v psql >/dev/null 2>&1 || { echo >&2 "I require psql but it's not installed.  Aborting."; exit 1; }
+
 ssh_socket=/tmp/session1
 
 function cleanup() {


### PR DESCRIPTION
Trying to get my fork back into master in an easily digestable way.  There are three minor changes here:

- Use Route53 ALIAS entries instead of CNAME.  These are cheaper and incorporate health checks.
- PKS needs specific tags on certain subnets or else it can't add load balancers.  This doesn't add ALL the tags required (since they're Bosh deployment specific), but it adds a few of the ones necessary and also paves the way for terraform to ignore future changes.
- Use Instance Profile instead of Access Key and Secret Keys.  I'd like to phase out IAM users completely from this repository eventually.
- Bunch of gitignore additions
- Error out of create database for control plane with an informative message so the user knows what went wrong.