### PR TITLE
Pin versions to avoid breaking changes during updates.

### DIFF
--- a/terraforming-control-plane/main.tf
+++ b/terraforming-control-plane/main.tf
@@ -2,10 +2,24 @@ provider "aws" {
   access_key = "${var.access_key}"
   secret_key = "${var.secret_key}"
   region     = "${var.region}"
+
+  version = "~> 1.60"
 }
 
 terraform {
   required_version = "< 0.12.0"
+}
+
+provider "random" {
+  version = "~> 2.0"
+}
+
+provider "template" {
+  version = "~> 1.0"
+}
+
+provider "tls" {
+  version = "~> 1.2"
 }
 
 resource "random_integer" "bucket" {

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -2,10 +2,24 @@ provider "aws" {
   access_key = "${var.access_key}"
   secret_key = "${var.secret_key}"
   region     = "${var.region}"
+
+  version = "~> 1.60"
 }
 
 terraform {
   required_version = "< 0.12.0"
+}
+
+provider "random" {
+  version = "~> 2.0"
+}
+
+provider "template" {
+  version = "~> 1.0"
+}
+
+provider "tls" {
+  version = "~> 1.2"
 }
 
 locals {

--- a/terraforming-pks/main.tf
+++ b/terraforming-pks/main.tf
@@ -2,10 +2,24 @@ provider "aws" {
   access_key = "${var.access_key}"
   secret_key = "${var.secret_key}"
   region     = "${var.region}"
+
+  version = "~> 1.60"
 }
 
 terraform {
   required_version = "< 0.12.0"
+}
+
+provider "random" {
+  version = "~> 2.0"
+}
+
+provider "template" {
+  version = "~> 1.0"
+}
+
+provider "tls" {
+  version = "~> 1.2"
 }
 
 locals {


### PR DESCRIPTION
This is to avoid breaking changes with the updated AWS providers.