### PR TITLE
fix cidr calculations

### DIFF
--- a/modules/calculate_subnets/main.tf
+++ b/modules/calculate_subnets/main.tf
@@ -1,0 +1,57 @@
+variable "vpc_cidr" {
+  default = "10.0.0.0/16"
+}
+
+locals {
+
+  cidr_breakout_map = {
+    "10.0.0.0/16" = {
+      "large" = 6
+      "small" = 10
+      "infra_index" = 64
+    }
+    "10.0.0.0/20" = {
+      "large" = 3
+      "small" = 6
+      "infra_index" = 32
+    }
+  }
+
+  newbits_to_large = "${lookup(local.cidr_breakout_map[var.vpc_cidr],"large")}"
+  newbits_to_small = "${lookup(local.cidr_breakout_map[var.vpc_cidr],"small")}"
+  index_for_ifra_subnet = "${lookup(local.cidr_breakout_map[var.vpc_cidr],"infra_index")}"
+
+  rds_cidr = "${cidrsubnet(var.vpc_cidr, local.newbits_to_large, 3)}"
+  pas_cidr      = "${cidrsubnet(var.vpc_cidr, local.newbits_to_large, 1)}"
+  services_cidr = "${cidrsubnet(var.vpc_cidr, local.newbits_to_large, 2)}"
+  pks_cidr      = "${cidrsubnet(var.vpc_cidr, local.newbits_to_large, 1)}"
+  pks_services_cidr = "${cidrsubnet(var.vpc_cidr, local.newbits_to_large, 2)}"
+  control_plane_cidr      = "${cidrsubnet(var.vpc_cidr, local.newbits_to_large, 1)}"
+  infrastructure_cidr = "${cidrsubnet(var.vpc_cidr, local.newbits_to_small, local.index_for_ifra_subnet)}"
+  public_cidr         = "${cidrsubnet(var.vpc_cidr, local.newbits_to_large, 0)}"
+}
+
+output "public_cidr" {
+  value = "${local.public_cidr}"
+}
+output "pas_cidr" {
+  value = "${local.pas_cidr}"
+}
+output "services_cidr" {
+  value = "${local.services_cidr}"
+}
+output "rds_cidr" {
+  value = "${local.rds_cidr}"
+}
+output "infrastructure_cidr" {
+  value = "${local.infrastructure_cidr}"
+}
+output "control_plane_cidr" {
+  value = "${local.control_plane_cidr}"
+}
+output "pks_cidr" {
+  value = "${local.pks_cidr}"
+}
+output "pks_services_cidr" {
+  value = "${local.pks_services_cidr}"
+}

--- a/modules/calculate_subnets/main.tf
+++ b/modules/calculate_subnets/main.tf
@@ -3,23 +3,25 @@ variable "vpc_cidr" {
 }
 
 locals {
+  cidr_split= "${split("/", var.vpc_cidr)}"
+  cidr_prefix = "${local.cidr_split[1]}"
 
   cidr_breakout_map = {
-    "10.0.0.0/16" = {
+    "16" = {
       "large" = 6
       "small" = 10
       "infra_index" = 64
     }
-    "10.0.0.0/20" = {
+    "20" = {
       "large" = 3
       "small" = 6
       "infra_index" = 32
     }
   }
 
-  newbits_to_large = "${lookup(local.cidr_breakout_map[var.vpc_cidr],"large")}"
-  newbits_to_small = "${lookup(local.cidr_breakout_map[var.vpc_cidr],"small")}"
-  index_for_ifra_subnet = "${lookup(local.cidr_breakout_map[var.vpc_cidr],"infra_index")}"
+  newbits_to_large = "${lookup(local.cidr_breakout_map[local.cidr_prefix],"large")}"
+  newbits_to_small = "${lookup(local.cidr_breakout_map[local.cidr_prefix],"small")}"
+  index_for_ifra_subnet = "${lookup(local.cidr_breakout_map[local.cidr_prefix],"infra_index")}"
 
   rds_cidr = "${cidrsubnet(var.vpc_cidr, local.newbits_to_large, 3)}"
   pas_cidr      = "${cidrsubnet(var.vpc_cidr, local.newbits_to_large, 1)}"

--- a/modules/control_plane/variables.tf
+++ b/modules/control_plane/variables.tf
@@ -38,6 +38,11 @@ variable "tags" {
   type = "map"
 }
 
+module "cidr_lookup" {
+  source = "../calculate_subnets"
+  vpc_cidr = "${var.vpc_cidr}"
+}
+
 locals {
-  control_plane_cidr = "${cidrsubnet(var.vpc_cidr, 6, 1)}"
+  control_plane_cidr = "${module.cidr_lookup.control_plane_cidr}"
 }

--- a/modules/infra/variables.tf
+++ b/modules/infra/variables.tf
@@ -55,7 +55,12 @@ variable "nat_ami_map" {
   }
 }
 
+module "cidr_lookup" {
+  source = "../calculate_subnets"
+  vpc_cidr = "${var.vpc_cidr}"
+}
+
 locals {
-  infrastructure_cidr = "${cidrsubnet(var.vpc_cidr, 10, 64)}"
-  public_cidr         = "${cidrsubnet(var.vpc_cidr, 6, 0)}"
+  infrastructure_cidr = "${module.cidr_lookup.infrastructure_cidr}"
+  public_cidr         = "${module.cidr_lookup.public_cidr}"
 }

--- a/modules/pas/variables.tf
+++ b/modules/pas/variables.tf
@@ -64,7 +64,12 @@ variable "tags" {
   type = "map"
 }
 
+module "cidr_lookup" {
+  source = "../calculate_subnets"
+  vpc_cidr = "${var.vpc_cidr}"
+}
+
 locals {
-  pas_cidr      = "${cidrsubnet(var.vpc_cidr, 6, 1)}"
-  services_cidr = "${cidrsubnet(var.vpc_cidr, 6, 2)}"
+  pas_cidr      =  "${module.cidr_lookup.pas_cidr}"
+  services_cidr =  "${module.cidr_lookup.services_cidr}"
 }

--- a/modules/pks/variables.tf
+++ b/modules/pks/variables.tf
@@ -38,7 +38,12 @@ variable "tags" {
   type = "map"
 }
 
+module "cidr_lookup" {
+  source = "../calculate_subnets"
+  vpc_cidr = "${var.vpc_cidr}"
+}
+
 locals {
-  pks_cidr          = "${cidrsubnet(var.vpc_cidr, 6, 1)}"
-  pks_services_cidr = "${cidrsubnet(var.vpc_cidr, 6, 2)}"
+  pks_cidr = "${module.cidr_lookup.pks_cidr}"
+  pks_services_cidr = "${module.cidr_lookup.pks_services_cidr}"
 }

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -41,6 +41,11 @@ variable "tags" {
   type = "map"
 }
 
+module "cidr_lookup" {
+  source = "../calculate_subnets"
+  vpc_cidr = "${var.vpc_cidr}"
+}
+
 locals {
-  rds_cidr = "${cidrsubnet(var.vpc_cidr, 6, 3)}"
+  rds_cidr = "${module.cidr_lookup.rds_cidr}"
 }

--- a/terraforming-control-plane/main.tf
+++ b/terraforming-control-plane/main.tf
@@ -2,6 +2,7 @@ provider "aws" {
   access_key = "${var.access_key}"
   secret_key = "${var.secret_key}"
   region     = "${var.region}"
+  version = "< 2.0.0"
 }
 
 terraform {

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -2,6 +2,7 @@ provider "aws" {
   access_key = "${var.access_key}"
   secret_key = "${var.secret_key}"
   region     = "${var.region}"
+  version = "< 2.0.0"
 }
 
 terraform {

--- a/terraforming-pks/main.tf
+++ b/terraforming-pks/main.tf
@@ -2,6 +2,7 @@ provider "aws" {
   access_key = "${var.access_key}"
   secret_key = "${var.secret_key}"
   region     = "${var.region}"
+  version = "< 2.0.0"
 }
 
 terraform {


### PR DESCRIPTION
Hello!

We're having issues with CIDR errors when we try to create a /20 VPC. If we set the CIDR prefix to /20 we get errors such as this:

```
* module.infra.data.template_file.infrastructure_subnet_gateways[2]: cidrhost: prefix of 32 does not accommodate a host numbered 1 in:

${cidrhost(element(aws_subnet.infrastructure_subnets.*.cidr_block, count.index), 1)}
```

This PR fixes this, plus it consolidates the cidr subnet calculations into a module so they are easier to understand and maintain.