### PR TITLE
Allow db name to be set for aws_db_instance

### DIFF
--- a/modules/rds/template.tf
+++ b/modules/rds/template.tf
@@ -62,6 +62,7 @@ resource "aws_db_instance" "rds" {
   skip_final_snapshot     = true
   backup_retention_period = 7
   apply_immediately       = true
+  name                    = "${var.env_name}"
 
   count = "${var.rds_instance_count}"
 


### PR DESCRIPTION
- required in order to create database in the DB instance