### PR TITLE
Re-introduce a flag to control route53.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ ops_manager_ami    = "ami-4f291f2f"
 rds_instance_count = 1
 dns_suffix         = "example.com"
 vpc_cidr           = "10.0.0.0/16"
+use_route53        = true
 
 ssl_cert = <<EOF
 -----BEGIN CERTIFICATE-----

--- a/modules/control_plane/dns.tf
+++ b/modules/control_plane/dns.tf
@@ -1,8 +1,6 @@
-locals {
-  use_route53 = "${var.region == "us-gov-west-1" ? 0 : 1}"
-}
-
 resource "aws_route53_record" "control_plane" {
+  count   = "${var.use_route53}"
+
   zone_id = "${var.zone_id}"
   name    = "plane.${var.env_name}.${var.dns_suffix}"
   type    = "CNAME"

--- a/modules/control_plane/outputs.tf
+++ b/modules/control_plane/outputs.tf
@@ -1,5 +1,5 @@
 output "domain" {
-  value = "${aws_route53_record.control_plane.name}"
+  value = "${aws_route53_record.control_plane.*.name}"
 }
 
 output "lb_target_groups" {

--- a/modules/control_plane/variables.tf
+++ b/modules/control_plane/variables.tf
@@ -22,6 +22,9 @@ variable "zone_id" {
   type = "string"
 }
 
+variable "use_route53" {
+}
+
 variable "dns_suffix" {
   type = "string"
 }

--- a/modules/infra/dns.tf
+++ b/modules/infra/dns.tf
@@ -7,18 +7,16 @@ locals {
   resource_dns_name_servers = "${join(",", flatten(concat(aws_route53_zone.pcf_zone.*.name_servers, list(list("")))))}"
   name_servers              = "${var.hosted_zone == "" ? local.resource_dns_name_servers : local.data_dns_name_servers}"
   hosted_zone_count         = "${var.hosted_zone == "" ? 0 : 1}"
-
-  use_route53 = "${var.region == "us-gov-west-1" ? 0 : 1}"
 }
 
 data "aws_route53_zone" "pcf_zone" {
-  count = "${local.use_route53 ? local.hosted_zone_count : 0}"
+  count = "${var.use_route53 ? local.hosted_zone_count : 0}"
 
   name = "${var.hosted_zone}"
 }
 
 resource "aws_route53_zone" "pcf_zone" {
-  count = "${local.use_route53 ? (1 - local.hosted_zone_count) : 0}"
+  count = "${var.use_route53 ? (1 - local.hosted_zone_count) : 0}"
 
   name = "${var.env_name}.${var.dns_suffix}"
 
@@ -26,7 +24,7 @@ resource "aws_route53_zone" "pcf_zone" {
 }
 
 resource "aws_route53_record" "name_servers" {
-  count = "${local.use_route53 ? (1 - local.hosted_zone_count) : 0}"
+  count = "${var.use_route53 ? (1 - local.hosted_zone_count) : 0}"
 
   zone_id = "${local.zone_id}"
   name    = "${var.env_name}.${var.dns_suffix}"

--- a/modules/infra/variables.tf
+++ b/modules/infra/variables.tf
@@ -15,6 +15,9 @@ variable "dns_suffix" {
   type = "string"
 }
 
+variable "use_route53" {
+}
+
 variable "availability_zones" {
   type = "list"
 }

--- a/modules/ops_manager/dns.tf
+++ b/modules/ops_manager/dns.tf
@@ -1,13 +1,9 @@
-locals {
-  use_route53 = "${var.region == "us-gov-west-1" ? 0 : 1}"
-}
-
 resource "aws_route53_record" "ops_manager_attached_eip" {
   name    = "pcf.${var.env_name}.${var.dns_suffix}"
   zone_id = "${var.zone_id}"
   type    = "A"
   ttl     = 300
-  count   = "${local.use_route53 ? var.vm_count : 0}"
+  count   = "${var.use_route53 ? var.vm_count : 0}"
 
   records = ["${coalesce(join("", aws_eip.ops_manager_attached.*.public_ip), aws_instance.ops_manager.private_ip)}"]
 }
@@ -17,7 +13,7 @@ resource "aws_route53_record" "ops_manager_unattached_eip" {
   zone_id = "${var.zone_id}"
   type    = "A"
   ttl     = 300
-  count   = "${local.use_route53 && (var.vm_count < 1) ? 1 : 0}"
+  count   = "${var.use_route53 && (var.vm_count < 1) ? 1 : 0}"
 
   records = ["${aws_eip.ops_manager_unattached.*.public_ip}"]
 }
@@ -27,7 +23,7 @@ resource "aws_route53_record" "optional_ops_manager" {
   zone_id = "${var.zone_id}"
   type    = "A"
   ttl     = 300
-  count   = "${local.use_route53 ? var.optional_count : 0}"
+  count   = "${var.use_route53 ? var.optional_count : 0}"
 
   records = ["${coalesce(join("", aws_eip.optional_ops_manager.*.public_ip), aws_instance.optional_ops_manager.private_ip)}"]
 }

--- a/modules/ops_manager/variables.tf
+++ b/modules/ops_manager/variables.tf
@@ -29,6 +29,8 @@ variable "additional_iam_roles_arn" {
 
 variable "dns_suffix" {}
 
+variable "use_route53" {}
+
 variable "zone_id" {}
 
 variable "bucket_suffix" {}

--- a/modules/pas/dns.tf
+++ b/modules/pas/dns.tf
@@ -1,9 +1,5 @@
-locals {
-  use_route53 = "${var.region == "us-gov-west-1" ? 0 : 1}"
-}
-
 resource "aws_route53_record" "wildcard_sys_dns" {
-  count   = "${local.use_route53 ? 1 : 0}"
+  count   = "${var.use_route53}"
   zone_id = "${var.zone_id}"
   name    = "*.sys.${var.env_name}.${var.dns_suffix}"
   type    = "A"
@@ -16,7 +12,7 @@ resource "aws_route53_record" "wildcard_sys_dns" {
 }
 
 resource "aws_route53_record" "wildcard_apps_dns" {
-  count   = "${local.use_route53 ? 1 : 0}"
+  count   = "${var.use_route53}"
   zone_id = "${var.zone_id}"
   name    = "*.apps.${var.env_name}.${var.dns_suffix}"
   type    = "A"
@@ -29,7 +25,7 @@ resource "aws_route53_record" "wildcard_apps_dns" {
 }
 
 resource "aws_route53_record" "ssh" {
-  count   = "${local.use_route53 ? 1 : 0}"
+  count   = "${var.use_route53}"
   zone_id = "${var.zone_id}"
   name    = "ssh.sys.${var.env_name}.${var.dns_suffix}"
   type    = "A"
@@ -42,7 +38,7 @@ resource "aws_route53_record" "ssh" {
 }
 
 resource "aws_route53_record" "tcp" {
-  count   = "${local.use_route53 ? 1 : 0}"
+  count   = "${var.use_route53}"
   zone_id = "${var.zone_id}"
   name    = "tcp.${var.env_name}.${var.dns_suffix}"
   type    = "A"

--- a/modules/pas/variables.tf
+++ b/modules/pas/variables.tf
@@ -40,6 +40,9 @@ variable "dns_suffix" {
   type = "string"
 }
 
+variable "use_route53" {
+}
+
 variable "create_backup_pas_buckets" {
   default = false
 }

--- a/modules/pks/dns.tf
+++ b/modules/pks/dns.tf
@@ -1,7 +1,3 @@
-locals {
-  use_route53 = "${var.region == "us-gov-west-1" ? 0 : 1}"
-}
-
 resource "aws_route53_record" "pks_api_dns" {
   zone_id = "${var.zone_id}"
   name    = "api.pks.${var.env_name}.${var.dns_suffix}"
@@ -13,5 +9,5 @@ resource "aws_route53_record" "pks_api_dns" {
     evaluate_target_health = true
   }
 
-  count = "${local.use_route53 ? 1 : 0}"
+  count = "${var.use_route53}"
 }

--- a/modules/pks/variables.tf
+++ b/modules/pks/variables.tf
@@ -34,6 +34,9 @@ variable "dns_suffix" {
   type = "string"
 }
 
+variable "use_route53" {
+}
+
 variable "tags" {
   type = "map"
 }

--- a/terraforming-control-plane/main.tf
+++ b/terraforming-control-plane/main.tf
@@ -37,6 +37,7 @@ module "infra" {
 
   hosted_zone = "${var.hosted_zone}"
   dns_suffix  = "${var.dns_suffix}"
+  use_route53 = "${var.use_route53}"
 
   internetless = false
   tags         = "${local.actual_tags}"
@@ -59,6 +60,7 @@ module "ops_manager" {
   vpc_cidr      = "${var.vpc_cidr}"
   dns_suffix    = "${var.dns_suffix}"
   zone_id       = "${module.infra.zone_id}"
+  use_route53   = "${var.use_route53}"
 
   # additional_iam_roles_arn = ["${module.pas.iam_pas_bucket_role_arn}"]
   bucket_suffix = "${local.bucket_suffix}"
@@ -78,6 +80,7 @@ module "control_plane" {
   region                  = "${var.region}"
   dns_suffix              = "${var.dns_suffix}"
   zone_id                 = "${module.infra.zone_id}"
+  use_route53             = "${var.use_route53}"
 }
 
 module "rds" {

--- a/terraforming-control-plane/variables.tf
+++ b/terraforming-control-plane/variables.tf
@@ -18,6 +18,11 @@ variable "hosted_zone" {
   default = ""
 }
 
+variable "use_route53" {
+  default = true
+  description = "Indicate whether or not to enable route53"
+}
+
 /**************
 * Ops Manager *
 ***************/

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -52,6 +52,7 @@ module "infra" {
 
   hosted_zone = "${var.hosted_zone}"
   dns_suffix  = "${var.dns_suffix}"
+  use_route53 = "${var.use_route53}"
 
   tags = "${local.actual_tags}"
 }
@@ -73,6 +74,7 @@ module "ops_manager" {
   vpc_cidr                 = "${var.vpc_cidr}"
   dns_suffix               = "${var.dns_suffix}"
   zone_id                  = "${module.infra.zone_id}"
+  use_route53              = "${var.use_route53}"
   additional_iam_roles_arn = ["${module.pas.iam_pas_bucket_role_arn}"]
   bucket_suffix            = "${local.bucket_suffix}"
 
@@ -121,6 +123,7 @@ module "pas" {
   bucket_suffix = "${local.bucket_suffix}"
   zone_id       = "${module.infra.zone_id}"
   dns_suffix    = "${var.dns_suffix}"
+  use_route53   = "${var.use_route53}"
 
   create_backup_pas_buckets    = "${var.create_backup_pas_buckets}"
   create_versioned_pas_buckets = "${var.create_versioned_pas_buckets}"

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -21,6 +21,11 @@ variable "vpc_cidr" {
   default = "10.0.0.0/16"
 }
 
+variable "use_route53" {
+  default = true
+  description = "Indicate whether or not to enable route53"
+}
+
 /******
 * PAS *
 *******/

--- a/terraforming-pks/main.tf
+++ b/terraforming-pks/main.tf
@@ -51,6 +51,7 @@ module "infra" {
 
   hosted_zone = "${var.hosted_zone}"
   dns_suffix  = "${var.dns_suffix}"
+  use_route53 = "${var.use_route53}"
 
   tags = "${local.actual_tags}"
 }
@@ -72,6 +73,7 @@ module "ops_manager" {
   vpc_cidr                 = "${var.vpc_cidr}"
   dns_suffix               = "${var.dns_suffix}"
   zone_id                  = "${module.infra.zone_id}"
+  use_route53              = "${var.use_route53}"
   bucket_suffix            = "${local.bucket_suffix}"
   additional_iam_roles_arn = ["${module.pks.pks_worker_iam_role_arn}", "${module.pks.pks_master_iam_role_arn}"]
 
@@ -102,8 +104,9 @@ module "pks" {
   private_route_table_ids = "${module.infra.deployment_route_table_ids}"
   public_subnet_ids       = "${module.infra.public_subnet_ids}"
 
-  zone_id    = "${module.infra.zone_id}"
-  dns_suffix = "${var.dns_suffix}"
+  zone_id     = "${module.infra.zone_id}"
+  dns_suffix  = "${var.dns_suffix}"
+  use_route53 = "${var.use_route53}"
 
   tags = "${local.actual_tags}"
 }

--- a/terraforming-pks/variables.tf
+++ b/terraforming-pks/variables.tf
@@ -21,6 +21,11 @@ variable "vpc_cidr" {
   default = "10.0.0.0/16"
 }
 
+variable "use_route53" {
+  default = true
+  description = "Indicate whether or not to enable route53"
+}
+
 /****************
 * Ops Manager *
 *****************/


### PR DESCRIPTION
Hello --

Here's the next PR: this is to re-introduce a simple flag to control route53 (versus conditional logic based on aws region name).

It also fixes some terraform boolean issues.

Thanks,

-- Jared 