### PR TITLE
More outputs for PKS

### DIFF
--- a/modules/pks/outputs.tf
+++ b/modules/pks/outputs.tf
@@ -1,3 +1,7 @@
+output "load_balancer_name" {
+  value = "${aws_lb.pks_api.name}"
+}
+
 output "pks_api_target_groups" {
   value = [
     "${aws_lb_target_group.pks_api_9021.name}",

--- a/terraforming-pks/outputs.tf
+++ b/terraforming-pks/outputs.tf
@@ -157,6 +157,10 @@ output "pks_api_endpoint" {
   value = "${module.pks.domain}"
 }
 
+output "pks_domain" {
+  value = "${var.env_name}.${var.dns_suffix}"
+}
+
 output "pks_subnet_ids" {
   value = "${module.pks.pks_subnet_ids}"
 }
@@ -213,4 +217,8 @@ output "services_subnet_cidrs" {
 
 output "services_subnet_gateways" {
   value = "${module.pks.services_subnet_gateways}"
+}
+
+output "tags" {
+  value = "${local.actual_tags}"
 }


### PR DESCRIPTION
These are two outputs I want from PKS terraforming that are currently not there, for "derived modules" having the actual tags is nice, and also the domain where PKS is for any potential wildcard domain naming.