### PR TITLE
Remove credentials and encourage defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.generated.yml
 OpsManager*onAWS.yml
 om.key
+credentials.yml
 *control-plane-*.yml
 *.tgz
 *secrets.yml

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Set of terraform modules for deploying Ops Manager, PAS and PKS infrastructure r
 - A RDS instance (optional)
 - A Virtual Private Network (VPC), subnets, Security Groups
 - Necessary s3 buckets
-- A NAT Box
+- NAT Gateway services
 - Network Load Balancers
 - An IAM User with proper permissions
 - Tagged resources
@@ -52,7 +52,7 @@ Note: You will also need to create a custom policy as the following and add to
 }
 ```
 
-## Deploying Ops Manager
+## Deploying Infrastructure
 
 First, you'll need to clone this repo. Then, depending on if you're deploying PAS or PKS you need to perform the following steps:
 
@@ -61,6 +61,7 @@ First, you'll need to clone this repo. Then, depending on if you're deploying PA
     - [terraforming-pks/](terraforming-pks/)
     - [terraforming-control-plane/](terraforming-control-plane/)
 1. Create [`terraform.tfvars`](/README.md#var-file) file
+1. Populate [credentials](/README.md#credentials) file or env variables
 1. Run terraform apply:
   ```bash
   terraform init
@@ -76,8 +77,6 @@ You should fill in the stub values with the correct content.
 
 ```hcl
 env_name           = "some-environment-name"
-access_key         = "access-key-id"
-secret_key         = "secret-access-key"
 region             = "us-west-1"
 availability_zones = ["us-west-1a", "us-west-1c"]
 ops_manager_ami    = "ami-4f291f2f"
@@ -106,11 +105,31 @@ tags = {
 }
 ```
 
+### Credentials
+
+Create a `credentials.yml` file with the following contents:
+
+```
+provider "aws" {
+  access_key = "YOUR_AWS_ACCESS_KEY"
+  secret_key = "YOUR_AWS_SECRET_KEY"
+  region     = "YOUR_AWS_REGION"
+}
+```
+
+Alternatively, populate the following environment variables before running the `terraform plan`:
+
+```
+$ export AWS_ACCESS_KEY_ID="anaccesskey"
+$ export AWS_SECRET_ACCESS_KEY="asecretkey"
+$ export AWS_DEFAULT_REGION="us-west-2"
+```
+
+See Terraform documentation on the [AWS Provider](https://www.terraform.io/docs/providers/aws/) for more ways on providing credentials, especially if using [EC2 Roles](https://www.terraform.io/docs/providers/aws/#ec2-role) or [`AWS_SESSION_TOKEN`](https://www.terraform.io/docs/providers/aws/#environment-variables).
+
 ### Variables
 
 - env_name: **(required)** An arbitrary unique name for namespacing resources
-- access_key **(required)** Your Amazon access_key, used for deployment
-- secret_key: **(required)** Your Amazon secret_key, also used for deployment
 - region: **(required)** Region you want to deploy your resources to
 - availability_zones: **(required)** List of AZs you want to deploy to
 - dns_suffix: **(required)** Domain to add environment subdomain to

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -73,6 +73,10 @@ resources:
       rds_instance_count: 0
       dns_suffix: aws.infrastructure.cf-app.com
       top_level_zone_id: ((terraforming-aws-root-zone-id))
+    env:
+      AWS_ACCESS_KEY_ID: ((aws_access_key_id))
+      AWS_SECRET_ACCESS_KEY: ((aws_secret_access_key))
+      AWS_DEFAULT_REGION: us-east-2
 
 - name: infrastructure-ci
   type: git

--- a/modules/infra/networking.tf
+++ b/modules/infra/networking.tf
@@ -52,7 +52,7 @@ resource "aws_subnet" "public_subnets" {
 
   # Ignore additional tags that are added for specifying clusters.
   lifecycle {
-    ignore_changes = ["tags.%", "tags.kubernetes"]
+    ignore_changes = ["tags"]
   }
 }
 

--- a/modules/pks/networking.tf
+++ b/modules/pks/networking.tf
@@ -37,7 +37,7 @@ resource "aws_subnet" "services_subnets" {
 
   # Ignore additional tags that are added for specifying clusters.
   lifecycle {
-    ignore_changes = ["tags.%", "tags.kubernetes"]
+    ignore_changes = ["tags"]
   }
 }
 

--- a/terraforming-control-plane/variables.tf
+++ b/terraforming-control-plane/variables.tf
@@ -1,8 +1,6 @@
 variable "env_name" {}
 
 variable "dns_suffix" {}
-variable "access_key" {}
-variable "secret_key" {}
 variable "region" {}
 
 variable "availability_zones" {
@@ -96,4 +94,16 @@ locals {
   }
 
   actual_tags = "${merge(var.tags, local.default_tags)}"
+}
+
+/*******************************
+ * Deprecated, Delete After Next Release *
+ *******************************/
+
+variable "access_key" {
+  default = ""
+}
+
+variable "secret_key" {
+  default = ""
 }

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -6,10 +6,6 @@ variable "hosted_zone" {
   default = ""
 }
 
-variable "access_key" {}
-
-variable "secret_key" {}
-
 variable "region" {}
 
 variable "availability_zones" {
@@ -165,4 +161,12 @@ variable "create_isoseg_resources" {
   type        = "string"
   default     = "0"
   description = "Optionally create a LB and DNS entries for a single isolation segment. Valid values are 0 or 1."
+}
+
+variable "access_key" {
+  default = ""
+}
+
+variable "secret_key" {
+  default = ""
 }

--- a/terraforming-pks/variables.tf
+++ b/terraforming-pks/variables.tf
@@ -6,10 +6,6 @@ variable "hosted_zone" {
   default = ""
 }
 
-variable "access_key" {}
-
-variable "secret_key" {}
-
 variable "region" {}
 
 variable "availability_zones" {
@@ -110,4 +106,17 @@ variable "tags" {
   type        = "map"
   default     = {}
   description = "Key/value tags to assign to all AWS resources"
+}
+
+
+/*******************************
+ * Deprecated, Delete After Next Release *
+ *******************************/
+
+variable "access_key" {
+  default = ""
+}
+
+variable "secret_key" {
+  default = ""
 }


### PR DESCRIPTION
Resolves #83 

**This will require changes to your pipeline**

Trying to nip this one in the bud, since it's starting to get propagated elsewhere.  The hard-coded way we have in terraforming-aws with using access key and secret is going to make things a lot worse down the line for EC2 Roles and session tokens, so remove this practice and reference the documentation on numerous alternatives on how to do this.