### PR TITLE
Create flag to control tcp routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ rds_instance_count = 1
 dns_suffix         = "example.com"
 vpc_cidr           = "10.0.0.0/16"
 use_route53        = true
+use_tcp_routes     = true
 
 ssl_cert = <<EOF
 -----BEGIN CERTIFICATE-----
@@ -119,6 +120,8 @@ tags = {
 - ssl_ca_private_key: **(optional)** Private key for above SSL CA certificate. Required unless `ssl_cert` is specified.
 - tags: **(optional)** A map of AWS tags that are applied to the created resources. By default, the following tags are set: Application = Cloud Foundry, Environment = $env_name
 - vpc_cidr: **(default: 10.0.0.0/16)** Internal CIDR block for the AWS VPC.
+- use_route53: **(default: true)** Controls whether or not Route53 DNS resources are created.
+- use_tcp_routes: **(default: true)** Controls whether or not tcp routing is enabled.
 
 ### Ops Manager (optional)
 - ops_manager_ami: **(optional)**  Ops Manager AMI, get the right AMI according to your region from the AWS guide downloaded from [Pivotal Network](https://network.pivotal.io/products/ops-manager) (if not provided you get no Ops Manager)

--- a/README.md
+++ b/README.md
@@ -121,15 +121,14 @@ tags = {
 - vpc_cidr: **(default: 10.0.0.0/16)** Internal CIDR block for the AWS VPC.
 
 ### Ops Manager (optional)
-- ops_manager_vm: **(default: true)** Set to false if you don't want an ops manager vm, but still want all the other resource included in the module.
-- ops_manager_ami: **(optional)**  Ops Manager AMI, get the right AMI according to your region from the AWS guide downloaded from [Pivotal Network](https://network.pivotal.io/products/ops-manager)
+- ops_manager_ami: **(optional)**  Ops Manager AMI, get the right AMI according to your region from the AWS guide downloaded from [Pivotal Network](https://network.pivotal.io/products/ops-manager) (if not provided you get no Ops Manager)
 - optional_ops_manager: **(default: false)** Set to true if you want an additional Ops Manager (useful for testing upgrades)
 - optional_ops_manager_ami: **(optional)**  Additional Ops Manager AMI, get the right AMI according to your region from the AWS guide downloaded from [Pivotal Network](https://network.pivotal.io/products/ops-manager)
 - ops_manager_instance_type: **(default: m4.large)** Ops Manager instance type
 - ops_manager_private: **(default: false)** Set to true if you want Ops Manager deployed in a private subnet instead of a public subnet
 
 ### S3 Buckets (optional) (PAS only)
-- create_backup_pas_buckets: **(default: false)**  
+- create_backup_pas_buckets: **(default: false)**
 - create_versioned_pas_buckets: **(default: false)**
 
 ### RDS (optional)

--- a/ci/assets/template/director-config.yml
+++ b/ci/assets/template/director-config.yml
@@ -5,8 +5,9 @@ az-configuration:
 properties-configuration:
   director_configuration:
     ntp_servers_string: 169.254.169.123
-{{if index . "ssl_cert"}}
   security_configuration:
+    opsmanager_root_ca_trusted_certs: true
+{{if index . "ssl_cert"}}
     trusted_certificates: |
 {{indent 6 .ssl_cert}}
 {{end}}

--- a/ci/assets/template/srt-config.yml
+++ b/ci/assets/template/srt-config.yml
@@ -21,6 +21,8 @@ product-properties:
     value: true
   .mysql_monitor.recipient_email:
     value: cf-infra@pivotal.io
+  .properties.stack_migration_acknowledgement:
+      value: x
   .properties.credhub_key_encryption_passwords:
     value:
     - key:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -139,12 +139,12 @@ jobs:
       trigger: true
       params:
         globs:
-        - '*AWS.yml'
+        - '*aws*.yml'
   - do:
     - task: opsman-url
       file: ci/scripts/terraforming/latest-opsman/task.yml
       params:
-        IAAS: AWS
+        IAAS: aws
         KEY: us-east-2
     - put: env-state-aws
       params:
@@ -248,12 +248,12 @@ jobs:
       trigger: true
       params:
         globs:
-        - '*AWS.yml'
+        - '*aws*.yml'
   - do:
     - task: opsman-url
       file: ci/scripts/terraforming/latest-opsman/task.yml
       params:
-        IAAS: AWS
+        IAAS: aws
         KEY: us-east-2
     - put: env-state-aws
       params:

--- a/modules/pas/dns.tf
+++ b/modules/pas/dns.tf
@@ -38,7 +38,7 @@ resource "aws_route53_record" "ssh" {
 }
 
 resource "aws_route53_record" "tcp" {
-  count   = "${var.use_route53}"
+  count   = "${var.use_route53 && var.use_tcp_routes ? 1 : 0}"
   zone_id = "${var.zone_id}"
   name    = "tcp.${var.env_name}.${var.dns_suffix}"
   type    = "A"

--- a/modules/pas/lbs.tf
+++ b/modules/pas/lbs.tf
@@ -138,10 +138,11 @@ resource "aws_lb_target_group" "ssh" {
 # TCP Load Balancer
 
 locals {
-  tcp_port_count = 10
+  tcp_port_count = "${var.use_tcp_routes ? 10 : 0}"
 }
 
 resource "aws_security_group" "tcp_lb" {
+  count       = "${var.use_tcp_routes}"
   name        = "tcp_lb_security_group"
   description = "Load Balancer TCP Security Group"
   vpc_id      = "${var.vpc_id}"
@@ -164,6 +165,7 @@ resource "aws_security_group" "tcp_lb" {
 }
 
 resource "aws_lb" "tcp" {
+  count                            = "${var.use_tcp_routes}"
   name                             = "${var.env_name}-tcp-lb"
   load_balancer_type               = "network"
   enable_cross_zone_load_balancing = true
@@ -185,7 +187,7 @@ resource "aws_lb_listener" "tcp" {
 }
 
 resource "aws_lb_target_group" "tcp" {
-  name     = "${var.env_name}-tg-${1024 + count.index}"
+  name     = "${var.env_name}-tcp-tg-${1024 + count.index}"
   port     = "${1024 + count.index}"
   protocol = "TCP"
   vpc_id   = "${var.vpc_id}"

--- a/modules/pas/variables.tf
+++ b/modules/pas/variables.tf
@@ -43,6 +43,9 @@ variable "dns_suffix" {
 variable "use_route53" {
 }
 
+variable "use_tcp_routes" {
+}
+
 variable "create_backup_pas_buckets" {
   default = false
 }

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -58,9 +58,8 @@ module "infra" {
 }
 
 module "ops_manager" {
-  source = "../modules/ops_manager"
-
-  vm_count       = "${var.ops_manager_vm ? 1 : 0}"
+  source         = "../modules/ops_manager"
+  vm_count       = "${var.ops_manager_vm == false ? 0 : (var.ops_manager_ami == "" ? 0 : 1)}"
   optional_count = "${var.optional_ops_manager ? 1 : 0}"
   subnet_id      = "${local.ops_man_subnet_id}"
 

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -119,10 +119,11 @@ module "pas" {
   public_subnet_ids  = "${module.infra.public_subnet_ids}"
   internetless       = "${var.internetless}"
 
-  bucket_suffix = "${local.bucket_suffix}"
-  zone_id       = "${module.infra.zone_id}"
-  dns_suffix    = "${var.dns_suffix}"
-  use_route53   = "${var.use_route53}"
+  bucket_suffix  = "${local.bucket_suffix}"
+  zone_id        = "${module.infra.zone_id}"
+  dns_suffix     = "${var.dns_suffix}"
+  use_route53    = "${var.use_route53}"
+  use_tcp_routes = "${var.use_tcp_routes}"
 
   create_backup_pas_buckets    = "${var.create_backup_pas_buckets}"
   create_versioned_pas_buckets = "${var.create_versioned_pas_buckets}"

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -26,6 +26,11 @@ variable "use_route53" {
   description = "Indicate whether or not to enable route53"
 }
 
+variable "use_tcp_routes" {
+  default = true
+  description = "Indicate whether or not to enable tcp routes and elbs"
+}
+
 /******
 * PAS *
 *******/

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -47,7 +47,8 @@ variable "create_backup_pas_buckets" {
 *****************/
 
 variable "ops_manager_ami" {
-  default = ""
+  type        = "string"
+  description = "Ops Manager AMI on AWS. Ops Manager VM will be skipped if this is empty"
 }
 
 variable "optional_ops_manager_ami" {
@@ -61,10 +62,6 @@ variable "ops_manager_instance_type" {
 variable "ops_manager_private" {
   default     = false
   description = "If true, the Ops Manager will be colocated with the BOSH director on the infrastructure subnet instead of on the public subnet"
-}
-
-variable "ops_manager_vm" {
-  default = true
 }
 
 variable "optional_ops_manager" {
@@ -154,12 +151,16 @@ variable "tags" {
   description = "Key/value tags to assign to all AWS resources"
 }
 
-/**************
-* Deprecated *
-***************/
+/*******************************
+ * Deprecated, Delete After Next Release *
+ *******************************/
 
 variable "create_isoseg_resources" {
   type        = "string"
   default     = "0"
   description = "Optionally create a LB and DNS entries for a single isolation segment. Valid values are 0 or 1."
+}
+
+variable "ops_manager_vm" {
+  default = true
 }

--- a/terraforming-pks/main.tf
+++ b/terraforming-pks/main.tf
@@ -59,7 +59,7 @@ module "infra" {
 module "ops_manager" {
   source = "../modules/ops_manager"
 
-  vm_count       = "${var.ops_manager_vm ? 1 : 0}"
+  vm_count       = "${var.ops_manager_vm == false ? 0 : (var.ops_manager_ami == "" ? 0 : 1)}"
   optional_count = "${var.optional_ops_manager ? 1 : 0}"
   subnet_id      = "${local.ops_man_subnet_id}"
 

--- a/terraforming-pks/variables.tf
+++ b/terraforming-pks/variables.tf
@@ -22,7 +22,7 @@ variable "vpc_cidr" {
 }
 
 variable "use_route53" {
-  default = true
+  default     = true
   description = "Indicate whether or not to enable route53"
 }
 
@@ -31,7 +31,9 @@ variable "use_route53" {
 *****************/
 
 variable "ops_manager_ami" {
-  default = ""
+  default     = ""
+  type        = "string"
+  description = "Ops Manager AMI on AWS. Ops Manager VM will be skipped if this is empty"
 }
 
 variable "optional_ops_manager_ami" {
@@ -45,10 +47,6 @@ variable "ops_manager_instance_type" {
 variable "ops_manager_private" {
   default     = false
   description = "If true, the Ops Manager will be colocated with the BOSH director on the infrastructure subnet instead of on the public subnet"
-}
-
-variable "ops_manager_vm" {
-  default = true
 }
 
 variable "optional_ops_manager" {
@@ -108,4 +106,12 @@ variable "tags" {
   type        = "map"
   default     = {}
   description = "Key/value tags to assign to all AWS resources"
+}
+
+/*******************************
+ * Deprecated, Delete After Next Release *
+ *******************************/
+
+variable "ops_manager_vm" {
+  default = true
 }


### PR DESCRIPTION
Hello --

Here's a PR to add functionality that let's users turn tcp routing on and off (along with associated load balancer, security group, listeners, route53 entries).

This is useful in environments that disallow tcp access to pas applications for security reasons.

Thanks,

-- Jared 