### PR TITLE
Changed DNS NS from comma to new line list as required

### DIFF
--- a/modules/infra/dns.tf
+++ b/modules/infra/dns.tf
@@ -3,8 +3,8 @@ locals {
   resource_zone_id = "${element(concat(aws_route53_zone.pcf_zone.*.zone_id, list("")), 0)}"
   zone_id          = "${var.hosted_zone == "" ? local.resource_zone_id : local.data_zone_id}"
 
-  data_dns_name_servers     = "${join(",", flatten(concat(data.aws_route53_zone.pcf_zone.*.name_servers, list(list("")))))}"
-  resource_dns_name_servers = "${join(",", flatten(concat(aws_route53_zone.pcf_zone.*.name_servers, list(list("")))))}"
+  data_dns_name_servers     = "${join("\n", flatten(concat(data.aws_route53_zone.pcf_zone.*.name_servers, list(list("")))))}"
+  resource_dns_name_servers = "${join("\n", flatten(concat(aws_route53_zone.pcf_zone.*.name_servers, list(list("")))))}"
   name_servers              = "${var.hosted_zone == "" ? local.resource_dns_name_servers : local.data_dns_name_servers}"
   hosted_zone_count         = "${var.hosted_zone == "" ? 0 : 1}"
 }


### PR DESCRIPTION
Fixed issue where terraform would create the new DNS hosted zone's NS record with the servers in a comma delimited list instead of one per line as specified by AWS for Route 53.