### PR TITLE
107 - open ports inside ops_manager_security_group so bosh create-env…

### DIFF
--- a/modules/ops_manager/security_group.tf
+++ b/modules/ops_manager/security_group.tf
@@ -24,6 +24,13 @@ resource "aws_security_group" "ops_manager_security_group" {
     to_port     = 443
   }
 
+  ingress {
+    self      = "true"
+    protocol  = "-1"
+    from_port = 0
+    to_port   = 0
+  }
+
   egress {
     cidr_blocks = ["${var.private ? var.vpc_cidr : "0.0.0.0/0"}"]
     protocol    = "-1"


### PR DESCRIPTION
… doesn't fail.

Reference: issue #107 

This doesn't have to be the ultimate solution but I don't know the full list of ports required. Please feel free to comment/modify.