### PR TITLE
Adding PKS API security group as output

### DIFF
--- a/modules/pks/outputs.tf
+++ b/modules/pks/outputs.tf
@@ -60,3 +60,7 @@ output "domain" {
 output "pks_master_security_group_id" {
   value = "${aws_security_group.pks_master_security_group.id}"
 }
+
+output "pks_api_lb_security_group_id" {
+  value = "${aws_security_group.pks_api_lb_security_group.id}"
+}

--- a/terraforming-pks/outputs.tf
+++ b/terraforming-pks/outputs.tf
@@ -193,6 +193,10 @@ output "pks_api_target_groups" {
   value = "${module.pks.pks_api_target_groups}"
 }
 
+output "pks_api_lb_security_group_id" {
+  value = "${module.pks.pks_api_lb_security_group_id}"
+}
+
 # PKS Services =================================================================
 
 output "services_subnet_ids" {


### PR DESCRIPTION
Adding the PKS API security group ID as an output.

This is a resolution to https://github.com/pivotal-cf/terraforming-aws/issues/102.