### PR TITLE
Bug Fix: Resolves issue since didn't see that PAS uses this value internally.

### DIFF
--- a/modules/ops_manager/outputs.tf
+++ b/modules/ops_manager/outputs.tf
@@ -43,7 +43,7 @@ output "ops_manager_iam_instance_profile_name" {
 }
 
 output "ops_manager_iam_user_name" {
-  value = "${aws_iam_user.ops_manager.*.name}"
+  value = "${element(concat(aws_iam_user.ops_manager.*.name, list("")), 0)}"
 }
 
 output "ops_manager_iam_user_access_key" {

--- a/modules/ops_manager/outputs.tf
+++ b/modules/ops_manager/outputs.tf
@@ -47,11 +47,11 @@ output "ops_manager_iam_user_name" {
 }
 
 output "ops_manager_iam_user_access_key" {
-  value = "${aws_iam_access_key.ops_manager.*.id}"
+  value = "${element(concat(aws_iam_access_key.ops_manager.*.id, list("")), 0)}"
 }
 
 output "ops_manager_iam_user_secret_key" {
-  value     = "${aws_iam_access_key.ops_manager.*.secret}"
+  value     = "${element(concat(aws_iam_access_key.ops_manager.*.secret, list("")), 0)}"
   sensitive = true
 }
 


### PR DESCRIPTION
Thought the value was just referenced externally to terraform, looks like it's referred to internally by the PAS module.