### PR TITLE
Fix infrastructure subnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ credentials.yml
 *control-plane-*.yml
 *.tgz
 *secrets.yml
+*override.tf

--- a/modules/infra/nat.tf
+++ b/modules/infra/nat.tf
@@ -1,5 +1,4 @@
 resource "aws_route_table" "deployment" {
-  count  = "${length(var.availability_zones)}"
   vpc_id = "${aws_vpc.vpc.id}"
 }
 
@@ -44,9 +43,9 @@ resource "aws_eip" "nat_eip" {
 }
 
 resource "aws_route" "toggle_internet" {
-  count = "${var.internetless ? 0 : length(var.availability_zones)}"
+  count = "${var.internetless ? 0 : 1}"
 
-  route_table_id         = "${element(aws_route_table.deployment.*.id, count.index)}"
+  route_table_id         = "${aws_route_table.deployment.id}"
   nat_gateway_id         = "${aws_nat_gateway.nat.id}"
   destination_cidr_block = "0.0.0.0/0"
 }

--- a/modules/infra/outputs.tf
+++ b/modules/infra/outputs.tf
@@ -31,23 +31,23 @@ output "public_subnet_cidrs" {
 }
 
 output "infrastructure_subnet_ids" {
-  value = ["${aws_subnet.infrastructure_subnets.*.id}"]
+  value = ["${aws_subnet.infrastructure_subnet.id}"]
 }
 
 output "infrastructure_subnets" {
-  value = ["${aws_subnet.infrastructure_subnets.*.id}"]
+  value = ["${aws_subnet.infrastructure_subnet.id}"]
 }
 
 output "infrastructure_subnet_availability_zones" {
-  value = ["${aws_subnet.infrastructure_subnets.*.availability_zone}"]
+  value = ["${aws_subnet.infrastructure_subnet.availability_zone}"]
 }
 
 output "infrastructure_subnet_cidrs" {
-  value = ["${aws_subnet.infrastructure_subnets.*.cidr_block}"]
+  value = ["${aws_subnet.infrastructure_subnet.cidr_block}"]
 }
 
 output "infrastructure_subnet_gateways" {
-  value = ["${data.template_file.infrastructure_subnet_gateways.*.rendered}"]
+  value = ["${data.template_file.infrastructure_subnet_gateway.rendered}"]
 }
 
 output "aws_lb_interface_endpoint_ips" {

--- a/modules/infra/vpc.tf
+++ b/modules/infra/vpc.tf
@@ -39,7 +39,7 @@ resource "aws_vpc_endpoint" "ec2" {
   vpc_id              = "${aws_vpc.vpc.id}"
   service_name        = "${local.ec2_address}"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = ["${aws_subnet.infrastructure_subnets.*.id}"]
+  subnet_ids          = ["${aws_subnet.infrastructure_subnet.id}"]
   private_dns_enabled = true
   security_group_ids  = ["${aws_security_group.vms_security_group.id}"]
 }
@@ -50,7 +50,7 @@ resource "aws_vpc_endpoint" "lb" {
   vpc_id              = "${aws_vpc.vpc.id}"
   service_name        = "${local.lb_api_address}"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = ["${aws_subnet.infrastructure_subnets.*.id}"]
+  subnet_ids          = ["${aws_subnet.infrastructure_subnet.id}"]
   private_dns_enabled = true
   security_group_ids  = ["${aws_security_group.vms_security_group.id}"]
 }

--- a/terraforming-control-plane/outputs.tf
+++ b/terraforming-control-plane/outputs.tf
@@ -38,8 +38,8 @@ output "public_subnet_cidrs" {
   value = "${module.infra.public_subnet_cidrs}"
 }
 
-output "infrastructure_subnet_ids" {
-  value = "${module.infra.infrastructure_subnet_ids}"
+output "infrastructure_subnet_id" {
+  value = "${element(module.infra.infrastructure_subnet_ids, 0)}"
 }
 
 output "infrastructure_subnets" {
@@ -201,3 +201,10 @@ output "control_plane_web_security_group" {
 output "control_plane_lb_ca_cert" {
   value = "${var.tls_ca_certificate}"
 }
+
+# Deprecated ===================================================================
+
+output "infrastructure_subnet_ids" {
+  value = "${module.infra.infrastructure_subnet_ids}"
+}
+

--- a/terraforming-pas/outputs.tf
+++ b/terraforming-pas/outputs.tf
@@ -136,8 +136,8 @@ output "public_subnet_cidrs" {
   value = "${module.infra.public_subnet_cidrs}"
 }
 
-output "infrastructure_subnet_ids" {
-  value = "${module.infra.infrastructure_subnet_ids}"
+output "infrastructure_subnet_id" {
+  value = "${element(module.infra.infrastructure_subnet_ids, 0)}"
 }
 
 output "infrastructure_subnets" {
@@ -303,4 +303,8 @@ output "management_subnet_cidrs" {
 
 output "management_subnet_gateways" {
   value = "${module.infra.infrastructure_subnet_gateways}"
+}
+
+output "infrastructure_subnet_ids" {
+  value = "${module.infra.infrastructure_subnet_ids}"
 }

--- a/terraforming-pks/outputs.tf
+++ b/terraforming-pks/outputs.tf
@@ -63,8 +63,8 @@ output "public_subnet_cidrs" {
   value = "${module.infra.public_subnet_cidrs}"
 }
 
-output "infrastructure_subnet_ids" {
-  value = "${module.infra.infrastructure_subnet_ids}"
+output "infrastructure_subnet_id" {
+  value = "${element(module.infra.infrastructure_subnet_ids, 0)}"
 }
 
 output "infrastructure_subnets" {
@@ -225,4 +225,10 @@ output "services_subnet_gateways" {
 
 output "tags" {
   value = "${local.actual_tags}"
+}
+
+# Deprecated ===================================================================
+
+output "infrastructure_subnet_ids" {
+  value = "${module.infra.infrastructure_subnet_ids}"
 }


### PR DESCRIPTION
There is no need for a second infrastructure subnet.

Also, directly accessing output information held in arrays from bosh-interpolate-based tools is not possible;
in order to support using tfvars/state as interpolatable variables, we've made the infrastructure subnet available without traversing any arrays.