### PR TITLE
Remove extra variables

### DIFF
--- a/terraforming-control-plane/terraform.tfvars.example
+++ b/terraforming-control-plane/terraform.tfvars.example
@@ -6,8 +6,6 @@ rds_instance_count = 1
 dns_suffix         = "example.com"
 vpc_cidr           = "10.0.0.0/16"
 use_route53        = true
-use_ssh_routes     = true
-use_tcp_routes     = true
 
 tls_ca_certificate = <<EOF
 -----BEGIN CERTIFICATE-----  


### PR DESCRIPTION
`use_ssh_routes` & `use_tcp_routes` are not valid variables from control plane terraform templates. 

We can remove them to avoid confusion