### PR TITLE
Harbor support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ credentials.yml
 *control-plane-*.yml
 *.tgz
 *secrets.yml
+*.tfoutput
+*.tfoutput.json

--- a/modules/harbor/dns.tf
+++ b/modules/harbor/dns.tf
@@ -1,0 +1,13 @@
+resource "aws_route53_record" "harbor_dns" {
+  zone_id = "${var.zone_id}"
+  name    = "harbor.${var.env_name}.${var.dns_suffix}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.harbor.dns_name}"
+    zone_id                = "${aws_lb.harbor.zone_id}"
+    evaluate_target_health = true
+  }
+
+  count = "${var.use_route53}"
+}

--- a/modules/harbor/lb.tf
+++ b/modules/harbor/lb.tf
@@ -1,0 +1,80 @@
+// Allow access to Harbor Registry and Notary
+resource "aws_security_group" "harbor_lb_security_group" {
+  name        = "harbor_lb_security_group"
+  description = "Harbor LB Security Group"
+  vpc_id      = "${var.vpc_id}"
+
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    protocol    = "tcp"
+    from_port   = 443
+    to_port     = 443
+  }
+
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    protocol    = "tcp"
+    from_port   = 4443
+    to_port     = 4443
+  }
+
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+  }
+
+  tags = "${merge(var.tags, map("Name", "${var.env_name}-harbor-lb-security-group"))}"
+}
+
+resource "aws_lb" "harbor" {
+  name                             = "${var.env_name}-harbor"
+  load_balancer_type               = "network"
+  enable_cross_zone_load_balancing = true
+  internal                         = false
+  subnets                          = ["${var.public_subnet_ids}"]
+}
+
+resource "aws_lb_listener" "harbor_443" {
+  load_balancer_arn = "${aws_lb.harbor.arn}"
+  port              = 443
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.harbor_443.arn}"
+  }
+}
+
+resource "aws_lb_target_group" "harbor_443" {
+  name     = "${var.env_name}-harbor-tg-443"
+  port     = 443
+  protocol = "TCP"
+  vpc_id   = "${var.vpc_id}"
+
+  health_check {
+    healthy_threshold   = 6
+    unhealthy_threshold = 6
+    interval            = 10
+    protocol            = "TCP"
+  }
+}
+
+resource "aws_lb_listener" "harbor_4443" {
+  load_balancer_arn = "${aws_lb.harbor.arn}"
+  port              = 4443
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.harbor_4443.arn}"
+  }
+}
+
+resource "aws_lb_target_group" "harbor_4443" {
+  name     = "${var.env_name}-harbor-tg-4443"
+  port     = 8443
+  protocol = "TCP"
+  vpc_id   = "${var.vpc_id}"
+}

--- a/modules/harbor/outputs.tf
+++ b/modules/harbor/outputs.tf
@@ -1,0 +1,23 @@
+output "load_balancer_name" {
+  value = "${aws_lb.harbor.name}"
+}
+
+output "harbor_target_groups" {
+  value = [
+    "${aws_lb_target_group.harbor_443.name}",
+    "${aws_lb_target_group.harbor_4443.name}",
+  ]
+}
+
+
+output "domain" {
+  value = "harbor.${var.env_name}.${var.dns_suffix}"
+}
+
+
+output "harbor_lb_security_group_id" {
+  value = "${aws_security_group.harbor_lb_security_group.id}"
+}
+output "harbor_lb_security_group_name" {
+  value = "${aws_security_group.harbor_lb_security_group.name}"
+}

--- a/modules/harbor/variables.tf
+++ b/modules/harbor/variables.tf
@@ -1,0 +1,26 @@
+variable "env_name" {
+  type = "string"
+}
+
+variable "vpc_id" {
+  type = "string"
+}
+
+variable "public_subnet_ids" {
+  type = "list"
+}
+
+variable "zone_id" {
+  type = "string"
+}
+
+variable "dns_suffix" {
+  type = "string"
+}
+
+variable "use_route53" {
+}
+
+variable "tags" {
+  type = "map"
+}

--- a/terraforming-pks/main.tf
+++ b/terraforming-pks/main.tf
@@ -129,3 +129,16 @@ module "rds" {
 
   tags = "${local.actual_tags}"
 }
+
+module "harbor" {
+  source = "../modules/harbor"
+  env_name                = "${var.env_name}"
+  vpc_id                  = "${module.infra.vpc_id}"
+  public_subnet_ids       = "${module.infra.public_subnet_ids}"
+
+  zone_id     = "${module.infra.zone_id}"
+  dns_suffix  = "${var.dns_suffix}"
+  use_route53 = "${var.use_route53}"
+
+  tags = "${local.actual_tags}"
+}

--- a/terraforming-pks/outputs.tf
+++ b/terraforming-pks/outputs.tf
@@ -226,3 +226,22 @@ output "services_subnet_gateways" {
 output "tags" {
   value = "${local.actual_tags}"
 }
+
+# Harbor =======================================================================
+
+output "harbor_endpoint" {
+  value = "${module.harbor.domain}"
+}
+
+
+output "harbor_target_groups" {
+  value = "${module.harbor.harbor_target_groups}"
+}
+
+output "harbor_lb_security_group_id" {
+  value = "${module.harbor.harbor_lb_security_group_id}"
+}
+
+output "harbor_lb_security_group_name" {
+  value = "${module.harbor.harbor_lb_security_group_name}"
+}

--- a/terraforming-pks/variables.tf
+++ b/terraforming-pks/variables.tf
@@ -98,6 +98,16 @@ variable "rds_instance_count" {
   default = 0
 }
 
+
+/*********
+* Harbor *
+**********/
+
+variable "enable_harbor" {
+  description = "Indicate whether to provision resources for Harbor"
+  default     = true
+}
+
 /*******
 * Tags *
 ********/


### PR DESCRIPTION
I have added support for harbor. This will create: 
- DNS Entry (harbor.<env-name>.<dbs_suffix>)
- Security Group (harbor_lb_security_group :: allow tcp/443, tcp/4443)
- Load Balancer (<env-name>-harbor 443, 4443)
- Target Groups (<env-name>-harbor-tg-443, <env-name>-harbor-tg-4443)

Variable `enable_habor` can be used to skip this provisioning.

Most of the time I find PKS install includes a Harbor install. 

Most code is copied over from pks module.

